### PR TITLE
Fix: Add npm scripts and nodemon configuration to MERN templates

### DIFF
--- a/templates/mern/javascript/server/nodemon.json
+++ b/templates/mern/javascript/server/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["*.js", "controllers/", "models/", "routes/", "middleware/"],
+  "ext": "js,json",
+  "ignore": ["node_modules/", "tests/"],
+  "delay": "1000"
+}

--- a/templates/mern/javascript/server/package.json
+++ b/templates/mern/javascript/server/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/templates/mern/typescript/server/nodemon.json
+++ b/templates/mern/typescript/server/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["*.js", "controllers/", "models/", "routes/", "middleware/"],
+  "ext": "js,json",
+  "ignore": ["node_modules/", "tests/"],
+  "delay": "1000"
+}

--- a/templates/mern/typescript/server/package.json
+++ b/templates/mern/typescript/server/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION

## Description
- Add `start` and `dev` scripts to MERN template package.json files
- Add nodemon.json configuration for auto-restart during development
- Update both JavaScript and TypeScript MERN templates
- Fixes missing development workflow tools

## Changes Made
- ✅ Updated `templates/mern/javascript/server/package.json`
- ✅ Updated `templates/mern/typescript/server/package.json`  
- ✅ Added `templates/mern/javascript/server/nodemon.json`
- ✅ Added `templates/mern/typescript/server/nodemon.json`

## Testing
- [x] Tested CLI scaffolding with MERN template
- [x] Verified npm scripts are included in generated projects
- [x] Verified nodemon configuration is properly added
- [x] No breaking changes

## Screenrecording
[Screencast From 2025-10-03 00-46-07.webm](https://github.com/user-attachments/assets/b74b3166-0b80-4d1f-a60d-4fd9f188200b)

Closes #105 