### PR TITLE
docs: move FAQs to separate FAQ.md and link it in README

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,39 @@
+## ❓ Frequently Asked Questions (FAQ)
+
+**Q1: What makes Celtrix stand out from other project scaffolding tools?**  
+A1: Celtrix provides ready-to-use templates, supports multiple popular stacks, and follows modern best practices, allowing you to start projects quickly without setting up everything manually.  
+
+**Q2: How do I add a new stack or template to Celtrix?**  
+A2: You can create a new template in the `templates/` folder following the existing folder structure. Test it using the CLI and then submit a Pull Request to contribute.  
+
+**Q3: Are projects created with Celtrix ready for production?**  
+A3: Celtrix projects give you a strong foundation for development. Some adjustments may be needed for production depending on your specific project requirements.  
+
+**Q4: Which stacks are currently available in Celtrix?**  
+A4: Celtrix currently supports MERN, MEAN, T3, Angular+Tailwind, and several other popular stacks. Contributors can add more stacks.  
+
+**Q5: Do I need to install anything globally to use Celtrix?**  
+A5: No, you don’t need global installations. Simply run `npx celtrix my-awesome-app` and follow the interactive prompts to start a project.  
+
+**Q6: Can I customize the generated templates?**  
+A6: Absolutely! You can modify components, styles, API setups, and configurations to match your project’s requirements.  
+
+**Q7: How can I report bugs or request new features?**  
+A7: Open a GitHub Issue in the Celtrix repository. Provide clear steps, screenshots, and a description to help maintainers understand and address your request.  
+
+**Q8: Does Celtrix support TypeScript projects?**  
+A8: Yes, most templates offer optional TypeScript support. You can choose TypeScript when setting up a new project.  
+
+**Q9: Can I use Celtrix for commercial projects?**  
+A9: Yes! Celtrix is open-source under the ISC license, so you can use it for personal or commercial projects following the license terms.  
+
+**Q10: How can I improve or update existing templates?**  
+A10: Fork the repository, make your changes in a separate branch, test them, and submit a Pull Request. Ensure your updates follow the coding guidelines.  
+
+**Q11: What prerequisites do I need to use Celtrix?**  
+A11: You only need Node.js and npm installed. Celtrix will handle other dependencies automatically during project setup.  
+
+**Q12: Where can I get support or join the Celtrix community?**  
+A12: You can ask questions via GitHub Discussions or join the community chat if available. Always stay respectful and constructive while engaging.
+
+---

--- a/README.md
+++ b/README.md
@@ -50,44 +50,9 @@ That's it! Follow the interactive prompts to customize your project.
 
 ---
 
-## ❓ Frequently Asked Questions (FAQ)
+## FAQ
 
-**Q1: What makes Celtrix stand out from other project scaffolding tools?**  
-A1: Celtrix provides ready-to-use templates, supports multiple popular stacks, and follows modern best practices, allowing you to start projects quickly without setting up everything manually.  
-
-**Q2: How do I add a new stack or template to Celtrix?**  
-A2: You can create a new template in the `templates/` folder following the existing folder structure. Test it using the CLI and then submit a Pull Request to contribute.  
-
-**Q3: Are projects created with Celtrix ready for production?**  
-A3: Celtrix projects give you a strong foundation for development. Some adjustments may be needed for production depending on your specific project requirements.  
-
-**Q4: Which stacks are currently available in Celtrix?**  
-A4: Celtrix currently supports MERN, MEAN, T3, Angular+Tailwind, and several other popular stacks. Contributors can add more stacks.  
-
-**Q5: Do I need to install anything globally to use Celtrix?**  
-A5: No, you don’t need global installations. Simply run `npx celtrix my-awesome-app` and follow the interactive prompts to start a project.  
-
-**Q6: Can I customize the generated templates?**  
-A6: Absolutely! You can modify components, styles, API setups, and configurations to match your project’s requirements.  
-
-**Q7: How can I report bugs or request new features?**  
-A7: Open a GitHub Issue in the Celtrix repository. Provide clear steps, screenshots, and a description to help maintainers understand and address your request.  
-
-**Q8: Does Celtrix support TypeScript projects?**  
-A8: Yes, most templates offer optional TypeScript support. You can choose TypeScript when setting up a new project.  
-
-**Q9: Can I use Celtrix for commercial projects?**  
-A9: Yes! Celtrix is open-source under the ISC license, so you can use it for personal or commercial projects following the license terms.  
-
-**Q10: How can I improve or update existing templates?**  
-A10: Fork the repository, make your changes in a separate branch, test them, and submit a Pull Request. Ensure your updates follow the coding guidelines.  
-
-**Q11: What prerequisites do I need to use Celtrix?**  
-A11: You only need Node.js and npm installed. Celtrix will handle other dependencies automatically during project setup.  
-
-**Q12: Where can I get support or join the Celtrix community?**  
-A12: You can ask questions via GitHub Discussions or join the community chat if available. Always stay respectful and constructive while engaging.
-
+You can now find the full list of FAQs here: [FAQ.md](./FAQ.md)
 
 ---
 


### PR DESCRIPTION
## Description
Moved the FAQ section from `README.md` into a dedicated `FAQ.md` file to improve readability and maintain project documentation structure.  
Updated `README.md` to include a direct link to `FAQ.md`.

## Related Issue
Fixes #140

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Other

## Checklist
- [x] My code follows the project’s style guidelines.
- [x] I have tested my changes locally.
- [x] I have updated documentation (if applicable).

## Additional Notes
This change separates frequently asked questions into their own file, making the `README.md` cleaner and easier to navigate.  
All links were tested to ensure correct navigation between `README.md` and `FAQ.md`.
