### PR TITLE
fix(hono): copy client template when CLI fails; always copy server

### DIFF
--- a/utils/templateManager.js
+++ b/utils/templateManager.js
@@ -39,18 +39,24 @@ export function copyTemplates(projectPath, config) {
       break;
     }
 
-    case 'hono': {
+ case 'hono': {
       const clientPath = path.join(projectPath, 'client');
       const serverPath = path.join(projectPath, 'server');
-      // const frontendTemplate = path.join(
-      //   __dirname, '..', 'templates', stack, config.language, 'client'
-      // );
+      const frontendTemplate = path.join(
+        __dirname, '..', 'templates', stack, config.language, 'client'
+      );
       const backendTemplate = path.join(
         __dirname, '..', 'templates', stack, config.language, 'server'
       );
-      
+
       logger.info('📂 Copying template files...');
+      // Always ensure server template exists (Cloudflare Workers structure)
       fs.copySync(backendTemplate, serverPath);
+      // Fallback: only copy client template if CLI didn't create it
+      if (!fs.existsSync(clientPath) || fs.readdirSync(clientPath).length === 0) {
+        logger.warn('⚠️ Hono client not found after CLI step — copying fallback client template');
+        fs.copySync(frontendTemplate, clientPath);
+      }
       break;
     }
     


### PR DESCRIPTION
## Description
Adds a safe fallback for the Hono stack so the client template is copied if the CLI (Vite) step fails or is skipped. Server template is always copied

## Related Issue
Fixes #<issue-number>

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Checklist
- [x] My code follows the project’s style guidelines.
- [ ] I have tested my changes locally.
- [ ] I have updated documentation (if applicable).

## Additional Notes
Not sure if this valid? but would be nice if someone can review it.

