### PR TITLE
Added new cli commands for mern-js and mern-ts

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ import { loginCommand } from "./commands/login.js";
 
 const orange = chalk.hex("#FF6200");
 
+const quickTemplates = {
+  "mern-js": { stack: "mern", language: "javascript" },
+  "mern-ts": { stack: "mern", language: "typescript" }
+};
+
 function detectPackageManager() {
   const userAgent = process.env.npm_config_user_agent;
   if (!userAgent) return "npm";
@@ -227,19 +232,43 @@ async function main() {
 
   let projectName = args.find(arg => !arg.startsWith('--') && !arg.startsWith('-'));
   let config;
+  const quickKey = args[0];
+let isQuick = false;
+let quickConfig = null;
+
+if (quickTemplates[quickKey]) {
+  isQuick = true;
+  quickConfig = quickTemplates[quickKey];
+}
 
   try {
 
-    if (!projectName) {
-      projectName = await askProjectName();
-    }
-    const stackAnswers = await askStackQuestions();
-    
-    packageManager = (await askPackageManager()).packageManager;
-    
+   if (isQuick) {
+  // QUICK MODE (mern-js / mern-ts)
+  console.log(chalk.green(`⚡ Using quick template: ${quickKey}`));
 
-    config = { ...stackAnswers, projectName, packageManager };
+  projectName = args[1] || (await askProjectName());
 
+  packageManager = (await askPackageManager()).packageManager;
+
+  config = {
+    stack: quickConfig.stack,       // always mern
+    language: quickConfig.language, // js or ts
+    projectName,
+    packageManager
+  };
+
+} else {
+  // NORMAL MODE (unchanged)
+  if (!projectName) {
+    projectName = await askProjectName();
+  }
+
+  const stackAnswers = await askStackQuestions();
+  packageManager = (await askPackageManager()).packageManager;
+
+  config = { ...stackAnswers, projectName, packageManager };
+}
     // Ask whether to install dependencies (handled in main script)
     const { installDeps } = await inquirer.prompt([
       {


### PR DESCRIPTION
## Description
This PR adds support for two new quick templates: `mern-js` and `mern-ts`.  
These allow users to skip both the stack-selection and language-selection prompts and move directly to:

- Package manager selection  
- Dependency installation confirmation  

This results in a much faster MERN project scaffolding flow.

## Related Issue
Closes #191

## Type of Change
- ✨ Feature addition  
- 🛠️ No breaking changes  
- 🧩 Existing interactive flow remains unchanged  

## Changes Made
- Added `quickTemplates` object with:
  - `mern-js` → MERN + JavaScript  
  - `mern-ts` → MERN + TypeScript  
- Updated CLI logic to:
  1. Detect if the first argument matches a quick template  
  2. Skip stack & language prompts when using quick templates  
  3. Continue with package manager and dependency installation prompts as usual  
- No changes made to the normal prompt-driven flow.

## How to Use (Tested Locally)

### MERN + JavaScript
`npx celtrix mern-js app-name`

<img width="780" alt="JS Example" src="https://github.com/user-attachments/assets/59916362-1997-4e63-a71f-9ab41b279233" />

### MERN + TypeScript
`npx celtrix mern-ts app-name`

<img width="827" alt="TS Example" src="https://github.com/user-attachments/assets/c17b2c9e-91da-4507-971a-fbc3987cb211" />

## Additional Notes
- Normal interactive mode is untouched.
- Fully backward compatible.
- Easy to extend with more templates in the future.
Before merging can you add wocs level tag to the issue.Thank you
