### PR TITLE
feat: prompt for github repo creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,6 +279,16 @@ if (quickTemplates[quickKey]) {
       },
     ]);
 
+    // Ask whether to create a github repo
+    const { createGitHubRepo } = await inquirer.prompt([
+      {
+        type: "confirm",
+        name: "createGitHubRepo",
+        message: "Do you want to create a GitHub Repository?",
+        default: true,
+      },
+    ]);
+
     console.log(chalk.yellow("\n🚀 Creating your project...\n"));
     await createProject(projectName, config, installDeps);
 


### PR DESCRIPTION
## Description
Added a confirmation prompt for the user to create a github repo

## Related Issue
Fixes #201

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Checklist
- [x] My code follows the project’s style guidelines.
- [x] I have tested my changes locally.
- [ ] I have updated documentation (if applicable).

## Additional Notes
Working screenshot:
Have a log that check the value of the user selection (Log removed in the PR)

<img width="1916" height="985" alt="image" src="https://github.com/user-attachments/assets/872df37d-c67e-4816-bc5c-50d7cef5501a" />
