### PR TITLE
Feat/frontend selector

### DIFF
--- a/createGithubRepo.js
+++ b/createGithubRepo.js
@@ -5,6 +5,7 @@ import fetch from "node-fetch";
 import { existsSync } from "fs";
 import path from "path";
 import { spawn } from "child_process";
+import { isPromptCancellation } from "./utils/shared.js";
 
 const GITHUB_OAUTH_CLIENT_ID =
   process.env.GITHUB_OAUTH_CLIENT_ID ||
@@ -72,19 +73,6 @@ function runGitCommand(args, cwd, stdioMode = "pipe") {
   });
 }
 
-/**
- * Returns true when an inquirer prompt was cancelled with Ctrl+C.
- *
- * @param {unknown} error - Prompt error.
- * @returns {boolean}
- */
-function isPromptCancellation(error) {
-  return (
-    error instanceof Error &&
-    (error.name === "ExitPromptError" ||
-      error.message.toLowerCase().includes("force closed"))
-  );
-}
 
 /**
  * Sends a form-encoded POST request and returns the JSON response.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ import inquirer from "inquirer";
 import chalk from "chalk";
 import gradient from "gradient-string";
 import figlet from "figlet";
+import ora from "ora";
+import boxen from "boxen";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -25,6 +27,38 @@ function detectPackageManager() {
   if (userAgent.includes("bun")) return "bun";
   if (userAgent.includes("npm")) return "npm";
   return "npm";
+}
+
+/**
+ * Returns true when an inquirer prompt was cancelled with Ctrl+C.
+ *
+ * @param {unknown} error - Prompt error.
+ * @returns {boolean}
+ */
+function isPromptCancellation(error) {
+  return (
+    error instanceof Error &&
+    (error.name === "ExitPromptError" ||
+      error.message.toLowerCase().includes("force closed"))
+  );
+}
+
+/**
+ * Parses CLI arguments by stripping the Node binary and the script/package
+ * runner prefix. Works reliably across npm, npx, pnpm, yarn, and bun
+ * regardless of how many segments the runner injects.
+ *
+ * @returns {string[]}
+ */
+function parseArgs() {
+  // Find the exact argument that represents the CLI entry point
+  const idx = process.argv.findIndex((arg, i) => {
+    if (i === 0) return false;
+    const basename = path.basename(arg);
+    return basename === "celtrix.js" || basename === "index.js" || basename === "celtrix";
+  });
+
+  return idx !== -1 ? process.argv.slice(idx + 1) : process.argv.slice(2);
 }
 
 function showBanner() {
@@ -92,7 +126,7 @@ async function askStackQuestions() {
         {
           name:
             chalk.whiteBright.bold("⚡ Next.js") +
-            chalk.gray(" → vannila modern stack"),
+            chalk.gray(" → vanilla modern stack"),
           value: "nextjs",
         },
         {
@@ -115,6 +149,44 @@ async function askStackQuestions() {
       ],
       pageSize: 10,
       default: "typescript",
+    },
+  ]);
+}
+
+async function askFrontendQuestions() {
+  return await inquirer.prompt([
+    {
+      type: "list",
+      name: "frontend",
+      message: "Select a frontend framework:",
+      choices: [
+        { name: chalk.blueBright.bold("React Router"), value: "react-router" },
+        { name: chalk.whiteBright.bold("Next.js"), value: "nextjs" },
+        { name: chalk.greenBright.bold("Nuxt"), value: "nuxt" },
+        { name: chalk.cyanBright.bold("TanStack"), value: "tanstack" },
+        { name: chalk.white.bold("Astro"), value: "astro" },
+        { name: chalk.redBright.bold("Svelte"), value: "svelte" },
+        { name: chalk.blue.bold("Solid"), value: "solid" },
+      ],
+      pageSize: 10,
+    },
+  ]);
+}
+
+async function askBackendFramework() {
+  return await inquirer.prompt([
+    {
+      type: "list",
+      name: "backend",
+      message: "Select a backend framework:",
+      choices: [
+        { name: chalk.magentaBright.bold("Hono"), value: "hono" },
+        { name: chalk.green.bold("Fastify"), value: "fastify" },
+        { name: chalk.blueBright.bold("Express"), value: "express" },
+        { name: orange.bold("Convex"), value: "convex" },
+        { name: chalk.gray("None (Frontend only)"), value: "none" },
+      ],
+      default: "express",
     },
   ]);
 }
@@ -201,17 +273,69 @@ function showHelp() {
   console.log(`  ${chalk.whiteBright('T3 Stack')}    ${chalk.gray('Next.js + tRPC + Prisma + Tailwind')}`);
   console.log(`  ${chalk.magentaBright('Hono')}        ${chalk.gray('Hono + Prisma + React')}`);
 
+  console.log(chalk.bold('\nSupported Frontends:'));
+  console.log(`  ${chalk.blueBright('React Router')}  ${chalk.gray('SPA routing with React')}`);
+  console.log(`  ${chalk.whiteBright('Next.js')}       ${chalk.gray('Full-stack React framework')}`);
+  console.log(`  ${chalk.greenBright('Nuxt')}          ${chalk.gray('Full-stack Vue framework')}`);
+  console.log(`  ${chalk.cyanBright('TanStack')}      ${chalk.gray('Type-safe routing & data fetching')}`);
+  console.log(`  ${chalk.white('Astro')}         ${chalk.gray('Content-driven static sites')}`);
+  console.log(`  ${chalk.redBright('Svelte')}        ${chalk.gray('Compile-time reactive UI')}`);
+  console.log(`  ${chalk.blue('Solid')}         ${chalk.gray('Fine-grained reactive UI')}`);
+
   console.log(chalk.gray('\nFor more information, visit: https://github.com/celtrix-os/Celtrix'));
 }
 
+/**
+ * Formats elapsed milliseconds into a human-readable string.
+ *
+ * @param {number} ms - Elapsed time in milliseconds.
+ * @returns {string}
+ */
+function formatElapsed(ms) {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Renders a styled post-scaffold summary box.
+ *
+ * @param {object} opts
+ * @param {string} opts.projectName
+ * @param {object} opts.config
+ * @param {boolean} opts.installedDeps
+ * @param {boolean} opts.createdRepo
+ * @param {number} opts.elapsed  - Scaffold duration in ms.
+ */
+function showSummaryBox({ projectName, config, installedDeps, createdRepo, elapsed }) {
+  const lines = [
+    `${chalk.bold("📦 Project:")}      ${chalk.greenBright(projectName)}`,
+    `${chalk.bold("🌐 Stack:")}        ${chalk.cyanBright(config.stack)}`,
+    `${chalk.bold("📖 Language:")}     ${chalk.yellow(config.language)}`,
+    ...(config.frontend ? [`${chalk.bold("🎨 Frontend:")}     ${chalk.blueBright(config.frontend)}`] : []),
+    ...(config.backend ? [`${chalk.bold("⚙️ Backend:")}      ${chalk.magentaBright(config.backend)}`] : []),
+    `${chalk.bold("📦 Pkg Manager:")}  ${chalk.magenta(config.packageManager)}`,
+    `${chalk.bold("📥 Deps:")}         ${installedDeps ? chalk.green("installed") : chalk.gray("skipped")}`,
+    `${chalk.bold("🐙 GitHub Repo:")}  ${createdRepo ? chalk.green("created") : chalk.gray("skipped")}`,
+    `${chalk.bold("⏱  Time:")}         ${chalk.white(formatElapsed(elapsed))}`,
+  ];
+
+  console.log(
+    boxen(lines.join("\n"), {
+      padding: 1,
+      margin: { top: 1, bottom: 1, left: 0, right: 0 },
+      borderColor: "green",
+      borderStyle: "round",
+      title: chalk.greenBright.bold("✅ Project Created"),
+      titleAlignment: "center",
+    })
+  );
+
+  console.log(chalk.gray("✨ Made with ❤️  by Celtrix ✨\n"));
+}
+
 async function main() {
-  let packageManager = detectPackageManager();
-  let args;
-  if(packageManager == "npm" || packageManager == "bun") {
-    args = process.argv.slice(2);
-  } else {
-    args = process.argv.slice(3);
-  }  
+  const args = parseArgs();
+
   // Handle version flag
   if (args.includes('--version') || args.includes('-v')) {
     showVersion();
@@ -232,44 +356,52 @@ async function main() {
   showBanner();
 
   let projectName = args.find(arg => !arg.startsWith('--') && !arg.startsWith('-'));
+  let packageManager = detectPackageManager();
   let config;
   const quickKey = args[0];
-let isQuick = false;
-let quickConfig = null;
+  let isQuick = false;
+  let quickConfig = null;
 
-if (quickTemplates[quickKey]) {
-  isQuick = true;
-  quickConfig = quickTemplates[quickKey];
-}
+  if (quickTemplates[quickKey]) {
+    isQuick = true;
+    quickConfig = quickTemplates[quickKey];
+  }
 
   try {
 
-   if (isQuick) {
-  // QUICK MODE (mern-js / mern-ts)
-  console.log(chalk.green(`⚡ Using quick template: ${quickKey}`));
+    if (isQuick) {
+      // QUICK MODE (mern-js / mern-ts)
+      console.log(chalk.green(`⚡ Using quick template: ${quickKey}`));
 
-  projectName = args[1] || (await askProjectName());
+      projectName = args[1] || (await askProjectName());
 
-  packageManager = (await askPackageManager()).packageManager;
+      packageManager = (await askPackageManager()).packageManager;
 
-  config = {
-    stack: quickConfig.stack,       // always mern
-    language: quickConfig.language, // js or ts
-    projectName,
-    packageManager
-  };
+      config = {
+        stack: quickConfig.stack,       // always mern
+        language: quickConfig.language, // js or ts
+        projectName,
+        packageManager
+      };
 
-} else {
-  // NORMAL MODE (unchanged)
-  if (!projectName) {
-    projectName = await askProjectName();
-  }
+    } else {
+      // NORMAL MODE (unchanged)
+      if (!projectName) {
+        projectName = await askProjectName();
+      }
 
-  const stackAnswers = await askStackQuestions();
-  packageManager = (await askPackageManager()).packageManager;
+      const stackAnswers = await askStackQuestions();
+      const frontendAnswers = await askFrontendQuestions();
+      const backendAnswers = await askBackendFramework();
+      packageManager = (await askPackageManager()).packageManager;
 
-  config = { ...stackAnswers, projectName, packageManager };
-}
+      config = { ...stackAnswers, ...frontendAnswers, ...backendAnswers, projectName, packageManager };
+    }
+
+    if (config.backend === "none") {
+      console.log(chalk.yellow("⚠️ Note: No backend framework selected. Creating a frontend-only project."));
+    }
+
     // Ask whether to install dependencies (handled in main script)
     const { installDeps } = await inquirer.prompt([
       {
@@ -290,14 +422,53 @@ if (quickTemplates[quickKey]) {
       },
     ]);
 
-    console.log(chalk.yellow("\n🚀 Creating your project...\n"));
-    await createProject(projectName, config, installDeps);
+    // --- Scaffold with spinner + timing ---
+    const startTime = Date.now();
+    const scaffoldSpinner = ora({
+      text: chalk.yellow("Scaffolding your project…"),
+      spinner: "dots12",
+    }).start();
 
-    if (createGitHubRepo) {
-      await createGithubRepo(projectName);
+    try {
+      await createProject(projectName, config, installDeps);
+      const elapsed = Date.now() - startTime;
+      scaffoldSpinner.succeed(
+        chalk.green(`Project scaffolded in ${formatElapsed(elapsed)}`)
+      );
+    } catch (err) {
+      scaffoldSpinner.fail(chalk.red("Scaffolding failed"));
+      throw err;
     }
 
+    // --- GitHub repo ---
+    let repoCreated = false;
+    if (createGitHubRepo) {
+      const repoSpinner = ora({
+        text: chalk.yellow("Starting GitHub repository setup…"),
+        spinner: "dots12",
+      }).start();
+      repoSpinner.stop(); // stop before interactive prompts inside createGithubRepo
+      await createGithubRepo(projectName);
+      repoCreated = true;
+    }
+
+    // --- Summary box ---
+    const totalElapsed = Date.now() - startTime;
+    showSummaryBox({
+      projectName,
+      config,
+      installedDeps: installDeps,
+      createdRepo: repoCreated,
+      elapsed: totalElapsed,
+    });
+
   } catch (err) {
+    // Graceful cancellation (Ctrl+C during any prompt)
+    if (isPromptCancellation(err)) {
+      console.log(chalk.yellow("\n👋 Cancelled — see you next time!\n"));
+      process.exit(0);
+    }
+
     console.log(chalk.red("❌ Error:"), err.message);
     process.exit(1);
   }

--- a/index.js
+++ b/index.js
@@ -191,6 +191,21 @@ async function askBackendFramework() {
   ]);
 }
 
+async function askRuntimeEnvironment() {
+  return await inquirer.prompt([
+    {
+      type: "list",
+      name: "runtime",
+      message: "Select a runtime environment:",
+      choices: [
+        { name: chalk.greenBright.bold("Node.js"), value: "node" },
+        { name: chalk.white.bold("Bun"), value: "bun" },
+      ],
+      default: "node",
+    },
+  ]);
+}
+
 async function askProjectName() {
   const { projectName } = await inquirer.prompt([
     {
@@ -313,6 +328,7 @@ function showSummaryBox({ projectName, config, installedDeps, createdRepo, elaps
     `${chalk.bold("📖 Language:")}     ${chalk.yellow(config.language)}`,
     ...(config.frontend ? [`${chalk.bold("🎨 Frontend:")}     ${chalk.blueBright(config.frontend)}`] : []),
     ...(config.backend ? [`${chalk.bold("⚙️ Backend:")}      ${chalk.magentaBright(config.backend)}`] : []),
+    `${chalk.bold("⚡ Runtime:")}      ${config.runtime === 'bun' ? chalk.white("Bun") : chalk.greenBright("Node.js")}`,
     `${chalk.bold("📦 Pkg Manager:")}  ${chalk.magenta(config.packageManager)}`,
     `${chalk.bold("📥 Deps:")}         ${installedDeps ? chalk.green("installed") : chalk.gray("skipped")}`,
     `${chalk.bold("🐙 GitHub Repo:")}  ${createdRepo ? chalk.green("created") : chalk.gray("skipped")}`,
@@ -376,12 +392,14 @@ async function main() {
       projectName = args[1] || (await askProjectName());
 
       packageManager = (await askPackageManager()).packageManager;
+      const runtimeAnswers = await askRuntimeEnvironment();
 
       config = {
         stack: quickConfig.stack,       // always mern
         language: quickConfig.language, // js or ts
         projectName,
-        packageManager
+        packageManager,
+        runtime: runtimeAnswers.runtime
       };
 
     } else {
@@ -393,9 +411,10 @@ async function main() {
       const stackAnswers = await askStackQuestions();
       const frontendAnswers = await askFrontendQuestions();
       const backendAnswers = await askBackendFramework();
+      const runtimeAnswers = await askRuntimeEnvironment();
       packageManager = (await askPackageManager()).packageManager;
 
-      config = { ...stackAnswers, ...frontendAnswers, ...backendAnswers, projectName, packageManager };
+      config = { ...stackAnswers, ...frontendAnswers, ...backendAnswers, ...runtimeAnswers, projectName, packageManager };
     }
 
     if (config.backend === "none") {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ import { fileURLToPath } from "url";
 import { createProject } from "./commands/scaffold.js";
 import { createGithubRepo } from "./createGithubRepo.js";
 import { loginCommand } from "./commands/login.js";
+import { gatherCustomConfig } from "./prompts/index.js";
+import { isPromptCancellation } from "./utils/shared.js";
 
 const orange = chalk.hex("#FF6200");
 
@@ -29,19 +31,7 @@ function detectPackageManager() {
   return "npm";
 }
 
-/**
- * Returns true when an inquirer prompt was cancelled with Ctrl+C.
- *
- * @param {unknown} error - Prompt error.
- * @returns {boolean}
- */
-function isPromptCancellation(error) {
-  return (
-    error instanceof Error &&
-    (error.name === "ExitPromptError" ||
-      error.message.toLowerCase().includes("force closed"))
-  );
-}
+const isVerbose = process.argv.includes("--verbose");
 
 /**
  * Parses CLI arguments by stripping the Node binary and the script/package
@@ -75,12 +65,19 @@ function showBanner() {
 }
 
 async function askStackQuestions() {
-  return await inquirer.prompt([
+  const stackAnswer = await inquirer.prompt([
     {
       type: "list",
       name: "stack",
       message: "Choose your stack:",
       choices: [
+        {
+          name:
+            gradient.pastel.multiline("⚡ Custom Stack") +
+            chalk.gray(" → Pick every piece of your stack"),
+          value: "custom",
+        },
+        new inquirer.Separator(chalk.gray("  ── Preset Stacks ──")),
         {
           name:
             chalk.blueBright.bold("⚡ MERN") +
@@ -136,9 +133,17 @@ async function askStackQuestions() {
           value: "hono",
         },
       ],
-      pageSize: 10,
-      default: "mern",
+      pageSize: 12,
+      default: "custom",
     },
+  ]);
+
+  // Skip language prompt for custom stack — it has its own language step.
+  if (stackAnswer.stack === "custom") {
+    return stackAnswer;
+  }
+
+  const langAnswer = await inquirer.prompt([
     {
       type: "list",
       name: "language",
@@ -151,44 +156,31 @@ async function askStackQuestions() {
       default: "typescript",
     },
   ]);
+
+  return { ...stackAnswer, ...langAnswer };
 }
 
-async function askFrontendQuestions() {
-  return await inquirer.prompt([
-    {
-      type: "list",
-      name: "frontend",
-      message: "Select a frontend framework:",
-      choices: [
-        { name: chalk.blueBright.bold("React Router"), value: "react-router" },
-        { name: chalk.whiteBright.bold("Next.js"), value: "nextjs" },
-        { name: chalk.greenBright.bold("Nuxt"), value: "nuxt" },
-        { name: chalk.cyanBright.bold("TanStack"), value: "tanstack" },
-        { name: chalk.white.bold("Astro"), value: "astro" },
-        { name: chalk.redBright.bold("Svelte"), value: "svelte" },
-        { name: chalk.blue.bold("Solid"), value: "solid" },
-      ],
-      pageSize: 10,
-    },
-  ]);
-}
-
-async function askBackendFramework() {
-  return await inquirer.prompt([
-    {
-      type: "list",
-      name: "backend",
-      message: "Select a backend framework:",
-      choices: [
-        { name: chalk.magentaBright.bold("Hono"), value: "hono" },
-        { name: chalk.green.bold("Fastify"), value: "fastify" },
-        { name: chalk.blueBright.bold("Express"), value: "express" },
-        { name: orange.bold("Convex"), value: "convex" },
-        { name: chalk.gray("None (Frontend only)"), value: "none" },
-      ],
-      default: "express",
-    },
-  ]);
+/**
+ * Returns human-readable frontend/backend labels derived from the chosen stack.
+ * The stack selection already determines which frameworks are used, so these
+ * labels are for display purposes only (summary box, config box).
+ *
+ * @param {string} stack - The selected stack identifier.
+ * @returns {{ frontend: string|null, backend: string|null }}
+ */
+function getStackMeta(stack) {
+  const meta = {
+    "mern":                    { frontend: "React",   backend: "Express" },
+    "mean":                    { frontend: "Angular", backend: "Express" },
+    "mevn":                    { frontend: "Vue",     backend: "Express" },
+    "mern+tailwind+auth":      { frontend: "React",   backend: "Express" },
+    "mean+tailwind+auth":      { frontend: "Angular", backend: "Express" },
+    "mevn+tailwind+auth":      { frontend: "Vue",     backend: "Express" },
+    "react+tailwind+firebase": { frontend: "React",   backend: null },
+    "nextjs":                  { frontend: "Next.js", backend: null },
+    "hono":                    { frontend: "React",   backend: "Hono" },
+  };
+  return meta[stack] || { frontend: null, backend: null };
 }
 
 async function askRuntimeEnvironment() {
@@ -271,7 +263,8 @@ function showHelp() {
 
   console.log(chalk.bold('Options:'));
   console.log(`  ${chalk.cyan('--version, -v')}     Show version number`);
-  console.log(`  ${chalk.cyan('--help, -h')}        Show help information\n`);
+  console.log(`  ${chalk.cyan('--help, -h')}        Show help information`);
+  console.log(`  ${chalk.cyan('--verbose')}         Show detailed error output\n`);
 
   console.log(chalk.bold('Examples:'));
   console.log(`  ${chalk.cyan('npx celtrix')}                 ${chalk.gray('# Interactive mode')}`);
@@ -279,23 +272,37 @@ function showHelp() {
   console.log(`  ${chalk.cyan('npx celtrix --version')}       ${chalk.gray('# Show version')}`);
   console.log(`  ${chalk.cyan('npx celtrix --help')}          ${chalk.gray('# Show this help')}\n`);
 
-  console.log(chalk.bold('Supported Stacks:'));
-  console.log(`  ${chalk.blueBright('MERN')}        ${chalk.gray('MongoDB + Express + React + Node.js')}`);
-  console.log(`  ${chalk.redBright('MEAN')}        ${chalk.gray('MongoDB + Express + Angular + Node.js')}`);
-  console.log(`  ${chalk.cyanBright('MEVN')}        ${chalk.gray('MongoDB + Express + Vue + Node.js')}`);
-  console.log(`  ${chalk.greenBright('MERN+Auth')}   ${chalk.gray('MERN with Tailwind & Authentication')}`);
-  console.log(`  ${chalk.magentaBright('React+Firebase')} ${chalk.gray('React + Tailwind + Firebase')}`);
-  console.log(`  ${chalk.whiteBright('T3 Stack')}    ${chalk.gray('Next.js + tRPC + Prisma + Tailwind')}`);
-  console.log(`  ${chalk.magentaBright('Hono')}        ${chalk.gray('Hono + Prisma + React')}`);
+  console.log(chalk.bold('Modes:'));
+  console.log(`  ${chalk.magentaBright('Custom Stack')}     ${chalk.gray('Pick every piece of your stack interactively')}`);
+  console.log(`  ${chalk.gray('Preset Stacks')}    ${chalk.gray('Choose a pre-configured full-stack template')}`);
 
-  console.log(chalk.bold('\nSupported Frontends:'));
-  console.log(`  ${chalk.blueBright('React Router')}  ${chalk.gray('SPA routing with React')}`);
-  console.log(`  ${chalk.whiteBright('Next.js')}       ${chalk.gray('Full-stack React framework')}`);
-  console.log(`  ${chalk.greenBright('Nuxt')}          ${chalk.gray('Full-stack Vue framework')}`);
-  console.log(`  ${chalk.cyanBright('TanStack')}      ${chalk.gray('Type-safe routing & data fetching')}`);
-  console.log(`  ${chalk.white('Astro')}         ${chalk.gray('Content-driven static sites')}`);
-  console.log(`  ${chalk.redBright('Svelte')}        ${chalk.gray('Compile-time reactive UI')}`);
-  console.log(`  ${chalk.blue('Solid')}         ${chalk.gray('Fine-grained reactive UI')}`);
+  console.log(chalk.bold('\nPreset Stacks:'));
+  console.log(`  ${chalk.blueBright('MERN')}             ${chalk.gray('MongoDB + Express + React + Node.js')}`);
+  console.log(`  ${chalk.redBright('MEAN')}             ${chalk.gray('MongoDB + Express + Angular + Node.js')}`);
+  console.log(`  ${chalk.cyanBright('MEVN')}             ${chalk.gray('MongoDB + Express + Vue + Node.js')}`);
+  console.log(`  ${chalk.greenBright('MERN+Auth')}        ${chalk.gray('MERN with Tailwind & Authentication')}`);
+  console.log(`  ${chalk.magentaBright('React+Firebase')}   ${chalk.gray('React + Tailwind + Firebase')}`);
+  console.log(`  ${chalk.whiteBright('Next.js')}          ${chalk.gray('Full-stack React framework')}`);
+  console.log(`  ${chalk.magentaBright('Hono')}             ${chalk.gray('Hono + Prisma + React')}`);
+
+  console.log(chalk.bold('\nCustom Stack — Frontends:'));
+  console.log(`  ${chalk.cyanBright('React Router')}     ${chalk.gray('React with file-based routing')}`);
+  console.log(`  ${chalk.white('Next.js')}          ${chalk.gray('Full-stack React framework')}`);
+  console.log(`  ${chalk.greenBright('Nuxt')}             ${chalk.gray('Full-stack Vue framework')}`);
+  console.log(`  ${chalk.hex('#FF6200')('TanStack')}         ${chalk.gray('Type-safe routing & data fetching')}`);
+  console.log(`  ${chalk.magentaBright('Astro')}            ${chalk.gray('Content-focused, island architecture')}`);
+  console.log(`  ${chalk.redBright('SvelteKit')}        ${chalk.gray('Cybernetically enhanced web apps')}`);
+  console.log(`  ${chalk.blueBright('SolidStart')}       ${chalk.gray('Fine-grained reactive UI framework')}`);
+
+  console.log(chalk.bold('\nCustom Stack — Backends:'));
+  console.log(`  ${chalk.hex('#FF6200')('Hono')}             ${chalk.gray('Ultrafast edge-ready web framework')}`);
+  console.log(`  ${chalk.white('Fastify')}          ${chalk.gray('Fast & low-overhead Node.js framework')}`);
+  console.log(`  ${chalk.yellowBright('Express')}          ${chalk.gray('Minimalist Node.js web framework')}`);
+  console.log(`  ${chalk.magentaBright('Convex')}           ${chalk.gray('Reactive backend-as-a-service')}`);
+
+  console.log(chalk.bold('\nSupported Runtimes:'));
+  console.log(`  ${chalk.greenBright('Node.js')}          ${chalk.gray('The standard JavaScript runtime')}`);
+  console.log(`  ${chalk.white('Bun')}              ${chalk.gray('Fast all-in-one JS runtime & toolkit')}`);
 
   console.log(chalk.gray('\nFor more information, visit: https://github.com/celtrix-os/Celtrix'));
 }
@@ -322,18 +329,45 @@ function formatElapsed(ms) {
  * @param {number} opts.elapsed  - Scaffold duration in ms.
  */
 function showSummaryBox({ projectName, config, installedDeps, createdRepo, elapsed }) {
+  const isCustom = config.stack === "custom";
+  const { frontend, backend } = isCustom
+    ? { frontend: config.frontend, backend: config.backend }
+    : getStackMeta(config.stack);
+
   const lines = [
     `${chalk.bold("📦 Project:")}      ${chalk.greenBright(projectName)}`,
-    `${chalk.bold("🌐 Stack:")}        ${chalk.cyanBright(config.stack)}`,
+    `${chalk.bold("🌐 Stack:")}        ${chalk.cyanBright(isCustom ? "Custom" : config.stack)}`,
     `${chalk.bold("📖 Language:")}     ${chalk.yellow(config.language)}`,
-    ...(config.frontend ? [`${chalk.bold("🎨 Frontend:")}     ${chalk.blueBright(config.frontend)}`] : []),
-    ...(config.backend ? [`${chalk.bold("⚙️ Backend:")}      ${chalk.magentaBright(config.backend)}`] : []),
+    ...(frontend && frontend !== "none" ? [`${chalk.bold("🎨 Frontend:")}     ${chalk.blueBright(frontend)}`] : []),
+    ...(backend && backend !== "none"   ? [`${chalk.bold("⚙️  Backend:")}      ${chalk.magentaBright(backend)}`] : []),
     `${chalk.bold("⚡ Runtime:")}      ${config.runtime === 'bun' ? chalk.white("Bun") : chalk.greenBright("Node.js")}`,
     `${chalk.bold("📦 Pkg Manager:")}  ${chalk.magenta(config.packageManager)}`,
+  ];
+
+  // Custom-stack expanded fields
+  if (isCustom) {
+    if (config.database && config.database.type !== "none") {
+      lines.push(`${chalk.bold("🗄️  Database:")}     ${chalk.cyanBright(config.database.type)}${config.database.provider ? chalk.gray(" via ") + chalk.white(config.database.provider) : ""}`);
+    }
+    if (config.orm && config.orm !== "none") {
+      lines.push(`${chalk.bold("🔗 ORM:")}           ${chalk.greenBright(config.orm)}`);
+    }
+    if (config.api && config.api !== "none") {
+      lines.push(`${chalk.bold("🔌 API:")}           ${chalk.blueBright(config.api)}`);
+    }
+    if (config.auth && config.auth !== "none") {
+      lines.push(`${chalk.bold("🔐 Auth:")}          ${chalk.magentaBright(config.auth)}`);
+    }
+    if (config.addons && config.addons.length > 0) {
+      lines.push(`${chalk.bold("🧩 Add-ons:")}       ${chalk.yellow(config.addons.join(", "))}`);
+    }
+  }
+
+  lines.push(
     `${chalk.bold("📥 Deps:")}         ${installedDeps ? chalk.green("installed") : chalk.gray("skipped")}`,
     `${chalk.bold("🐙 GitHub Repo:")}  ${createdRepo ? chalk.green("created") : chalk.gray("skipped")}`,
     `${chalk.bold("⏱  Time:")}         ${chalk.white(formatElapsed(elapsed))}`,
-  ];
+  );
 
   console.log(
     boxen(lines.join("\n"), {
@@ -403,22 +437,32 @@ async function main() {
       };
 
     } else {
-      // NORMAL MODE (unchanged)
+      // NORMAL MODE
       if (!projectName) {
         projectName = await askProjectName();
       }
 
       const stackAnswers = await askStackQuestions();
-      const frontendAnswers = await askFrontendQuestions();
-      const backendAnswers = await askBackendFramework();
-      const runtimeAnswers = await askRuntimeEnvironment();
-      packageManager = (await askPackageManager()).packageManager;
 
-      config = { ...stackAnswers, ...frontendAnswers, ...backendAnswers, ...runtimeAnswers, projectName, packageManager };
+      if (stackAnswers.stack === "custom") {
+        // ── Custom Stack Flow ──
+        console.log(chalk.gray("\n── Customise your tech stack ──\n"));
+        const customConfig = await gatherCustomConfig();
+        packageManager = (await askPackageManager()).packageManager;
+        config = { stack: "custom", ...customConfig, projectName, packageManager };
+      } else {
+        // ── Preset Stack Flow ──
+        const runtimeAnswers = await askRuntimeEnvironment();
+        packageManager = (await askPackageManager()).packageManager;
+        config = { ...stackAnswers, ...runtimeAnswers, projectName, packageManager };
+      }
     }
 
-    if (config.backend === "none") {
-      console.log(chalk.yellow("⚠️ Note: No backend framework selected. Creating a frontend-only project."));
+    if (config.stack !== "custom") {
+      const { backend: stackBackend } = getStackMeta(config.stack);
+      if (!stackBackend) {
+        console.log(chalk.yellow("⚠️ Note: This stack is frontend-only — no backend server will be created."));
+      }
     }
 
     // Ask whether to install dependencies (handled in main script)
@@ -427,6 +471,16 @@ async function main() {
         type: "confirm",
         name: "installDeps",
         message: "Do you want to install dependencies?",
+        default: true,
+      },
+    ]);
+
+    // Ask whether to initialize a git repo
+    const { initGit } = await inquirer.prompt([
+      {
+        type: "confirm",
+        name: "initGit",
+        message: "Initialize a git repository?",
         default: true,
       },
     ]);
@@ -459,14 +513,25 @@ async function main() {
       throw err;
     }
 
+    // --- Git init ---
+    if (initGit && !createGitHubRepo) {
+      // Only run standalone git init when NOT creating a GitHub repo
+      // (createGithubRepo handles git init + remote + push itself)
+      const projectPath = path.join(process.cwd(), projectName);
+      try {
+        const { execSync } = await import("child_process");
+        execSync("git init", { cwd: projectPath, stdio: "ignore" });
+        execSync("git add .", { cwd: projectPath, stdio: "ignore" });
+        execSync('git commit -m "Initial commit"', { cwd: projectPath, stdio: "ignore" });
+        console.log(chalk.green("\n🎉 Git repository initialized with initial commit."));
+      } catch {
+        console.log(chalk.yellow("\n⚠️  Could not initialize git — you can run 'git init' manually."));
+      }
+    }
+
     // --- GitHub repo ---
     let repoCreated = false;
     if (createGitHubRepo) {
-      const repoSpinner = ora({
-        text: chalk.yellow("Starting GitHub repository setup…"),
-        spinner: "dots12",
-      }).start();
-      repoSpinner.stop(); // stop before interactive prompts inside createGithubRepo
       await createGithubRepo(projectName);
       repoCreated = true;
     }
@@ -489,6 +554,9 @@ async function main() {
     }
 
     console.log(chalk.red("❌ Error:"), err.message);
+    if (isVerbose && err.stack) {
+      console.log(chalk.gray(err.stack));
+    }
     process.exit(1);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -371,6 +371,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.5.tgz",
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",

--- a/prompts/addons.js
+++ b/prompts/addons.js
@@ -1,0 +1,52 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * Add-on options grouped by category for the multi-select prompt.
+ */
+const ADDON_OPTIONS = [
+  // — Tooling —
+  new inquirer.Separator(chalk.gray.bold("  ── Tooling ──")),
+  { label: "Biome",     color: chalk.cyanBright,     desc: "Fast formatter & linter",            value: "biome" },
+  { label: "Husky",     color: chalk.yellowBright,   desc: "Git hooks made easy",                value: "husky" },
+
+  // — Infrastructure —
+  new inquirer.Separator(chalk.gray.bold("  ── Infrastructure ──")),
+  { label: "Nx",        color: chalk.blueBright,     desc: "Monorepo build orchestration",       value: "nx"    },
+
+  // — AI —
+  new inquirer.Separator(chalk.gray.bold("  ── AI ──")),
+  { label: "Vercel AI SDK", color: chalk.white,      desc: "Build AI-powered applications",     value: "vercel-ai-sdk" },
+];
+
+/**
+ * Prompts the user to select optional add-ons via a multi-select (checkbox) prompt.
+ * Options are grouped logically by category using separators.
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[10/10]".
+ * @returns {Promise<{ addons: string[] }>}
+ */
+export async function askAddons(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { addons } = await inquirer.prompt([
+    {
+      type: "checkbox",
+      name: "addons",
+      message: chalk.bold(`${prefix}Select add-ons ${chalk.dim("(space to toggle, enter to confirm)")}:`),
+      choices: ADDON_OPTIONS.map((opt) => {
+        // Pass through separator instances as-is
+        if (opt instanceof inquirer.Separator) return opt;
+        return {
+          name:
+            opt.color(`  ${opt.label}`) +
+            chalk.gray(` → ${opt.desc}`),
+          value: opt.value,
+        };
+      }),
+      pageSize: 12,
+    },
+  ]);
+
+  return { addons };
+}

--- a/prompts/api.js
+++ b/prompts/api.js
@@ -1,0 +1,39 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * API type options available for selection.
+ */
+const API_OPTIONS = [
+  { label: "tRPC", color: chalk.blueBright,     desc: "End-to-end type-safe APIs",        value: "trpc" },
+  { label: "oRPC", color: chalk.cyanBright,     desc: "Type-safe APIs with OpenAPI",       value: "orpc" },
+  { label: "None", color: chalk.gray,            desc: "REST / manual API setup",           value: "none" },
+];
+
+/**
+ * Prompts the user to select an API type.
+ * Should be skipped when the backend selection is "none".
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[7/10]".
+ * @returns {Promise<{ api: string }>}
+ */
+export async function askAPI(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { api } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "api",
+      message: chalk.bold(`${prefix}Select an API type:`),
+      choices: API_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`${opt.value === "none" ? "◻" : "⚡"} ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      default: "trpc",
+    },
+  ]);
+
+  return { api };
+}

--- a/prompts/auth.js
+++ b/prompts/auth.js
@@ -1,0 +1,38 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * Authentication provider options.
+ */
+const AUTH_OPTIONS = [
+  { label: "Clerk",       color: chalk.magentaBright,  desc: "Drop-in auth with prebuilt UI",       value: "clerk"       },
+  { label: "Better Auth", color: chalk.cyanBright,     desc: "Framework-agnostic TS auth library",  value: "better-auth" },
+  { label: "None",        color: chalk.gray,            desc: "No auth provider",                    value: "none"        },
+];
+
+/**
+ * Prompts the user to select an authentication provider.
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[8/10]".
+ * @returns {Promise<{ auth: string }>}
+ */
+export async function askAuth(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { auth } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "auth",
+      message: chalk.bold(`${prefix}Select an auth provider:`),
+      choices: AUTH_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`${opt.value === "none" ? "◻" : "⚡"} ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      default: "better-auth",
+    },
+  ]);
+
+  return { auth };
+}

--- a/prompts/backend.js
+++ b/prompts/backend.js
@@ -1,0 +1,42 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * Backend framework options available for selection.
+ */
+const BACKEND_OPTIONS = [
+  { label: "Hono",     color: chalk.hex("#FF6200"),   desc: "Ultrafast edge-ready web framework",     value: "hono"    },
+  { label: "Fastify",  color: chalk.white,            desc: "Fast & low-overhead Node.js framework",  value: "fastify" },
+  { label: "Express",  color: chalk.yellowBright,     desc: "Minimalist Node.js web framework",       value: "express" },
+  { label: "Convex",   color: chalk.magentaBright,    desc: "Reactive backend-as-a-service",          value: "convex"  },
+  { label: "None",     color: chalk.gray,             desc: "Frontend only, no backend",              value: "none"    },
+];
+
+/**
+ * Prompts the user to select a backend framework.
+ * The "none" option is handled gracefully — it returns { backend: "none" }.
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[3/10]".
+ * @returns {Promise<{ backend: string }>}
+ */
+export async function askBackend(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { backend } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "backend",
+      message: chalk.bold(`${prefix}Select a backend framework:`),
+      choices: BACKEND_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`${opt.value === "none" ? "◻" : "⚡"} ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      pageSize: 10,
+      default: "hono",
+    },
+  ]);
+
+  return { backend };
+}

--- a/prompts/database.js
+++ b/prompts/database.js
@@ -1,0 +1,51 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+import { askDatabaseSetup } from "./databaseSetup.js";
+
+/**
+ * Database engine options available for selection.
+ */
+const DATABASE_OPTIONS = [
+  { label: "SQLite",    color: chalk.cyanBright,      desc: "Lightweight embedded database",    value: "sqlite"  },
+  { label: "MySQL",     color: chalk.hex("#F29111"),   desc: "Popular relational database",      value: "mysql"   },
+  { label: "PostgreSQL", color: chalk.blueBright,      desc: "Advanced open-source RDBMS",       value: "postgres" },
+  { label: "MongoDB",   color: chalk.greenBright,      desc: "Document-oriented NoSQL database", value: "mongodb" },
+  { label: "None",      color: chalk.gray,             desc: "No database",                      value: "none"    },
+];
+
+/**
+ * Prompts the user to select a database, and if one is selected,
+ * follows up with the provider/setup prompt.
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[5/10]".
+ * @returns {Promise<{ database: { type: string, provider: string } }>}
+ */
+export async function askDatabase(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { databaseType } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "databaseType",
+      message: chalk.bold(`${prefix}Select a database:`),
+      choices: DATABASE_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`${opt.value === "none" ? "◻" : "⚡"} ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      pageSize: 10,
+      default: "postgres",
+    },
+  ]);
+
+  // If "none" is selected, skip the provider prompt
+  if (databaseType === "none") {
+    return { database: { type: "none", provider: "" } };
+  }
+
+  // Trigger the conditional setup prompt (Issue #214)
+  const { provider } = await askDatabaseSetup(databaseType);
+
+  return { database: { type: databaseType, provider } };
+}

--- a/prompts/databaseSetup.js
+++ b/prompts/databaseSetup.js
@@ -1,0 +1,59 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * Maps each database type to its available provider/setup options.
+ * Easily extensible — add a new DB type or provider by appending to the map.
+ */
+const SETUP_OPTIONS = {
+  sqlite: [
+    { label: "Turso",  color: chalk.cyanBright,    desc: "Edge-hosted distributed SQLite",  value: "turso" },
+    { label: "Local",  color: chalk.gray,           desc: "Local file-based SQLite",         value: "local" },
+  ],
+  postgres: [
+    { label: "Neon",      color: chalk.greenBright,    desc: "Serverless Postgres",             value: "neon"     },
+    { label: "Supabase",  color: chalk.hex("#3FCF8E"),  desc: "Open-source Firebase alternative", value: "supabase" },
+    { label: "Local",     color: chalk.gray,            desc: "Self-hosted PostgreSQL",          value: "local"    },
+  ],
+  mysql: [
+    { label: "PlanetScale", color: chalk.yellowBright,  desc: "Serverless MySQL platform",       value: "planetscale" },
+    { label: "Local",       color: chalk.gray,           desc: "Self-hosted MySQL",               value: "local"       },
+  ],
+  mongodb: [
+    { label: "MongoDB Atlas", color: chalk.greenBright,  desc: "Cloud-hosted MongoDB",            value: "atlas" },
+    { label: "Local",         color: chalk.gray,          desc: "Self-hosted MongoDB",             value: "local" },
+  ],
+};
+
+/**
+ * Prompts for database setup/provider based on the selected database type.
+ * Only called when the user has selected a database (not "none").
+ *
+ * @param {string} databaseType - The chosen database type (sqlite, postgres, etc.).
+ * @returns {Promise<{ provider: string }>}
+ */
+export async function askDatabaseSetup(databaseType) {
+  const options = SETUP_OPTIONS[databaseType];
+
+  // If no setup options exist for this DB type, default to "local"
+  if (!options || options.length === 0) {
+    return { provider: "local" };
+  }
+
+  const { provider } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "provider",
+      message: chalk.bold(`Select a ${chalk.cyanBright(databaseType)} provider:`),
+      choices: options.map((opt) => ({
+        name:
+          opt.color.bold(`⚡ ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      default: options[0].value,
+    },
+  ]);
+
+  return { provider };
+}

--- a/prompts/frontend.js
+++ b/prompts/frontend.js
@@ -1,0 +1,44 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * Frontend framework options available for selection.
+ * Each entry defines its display label, chalk color, description, and config value.
+ */
+const FRONTEND_OPTIONS = [
+  { label: "React Router",  color: chalk.cyanBright,      desc: "React with file-based routing",        value: "react-router" },
+  { label: "Next.js",       color: chalk.white,            desc: "Full-stack React framework",            value: "nextjs"       },
+  { label: "Nuxt",          color: chalk.greenBright,      desc: "Full-stack Vue framework",              value: "nuxt"         },
+  { label: "TanStack",      color: chalk.hex("#FF6200"),   desc: "Type-safe routing & data fetching",     value: "tanstack"     },
+  { label: "Astro",         color: chalk.magentaBright,    desc: "Content-focused, island architecture",  value: "astro"        },
+  { label: "SvelteKit",     color: chalk.redBright,        desc: "Cybernetically enhanced web apps",      value: "svelte"       },
+  { label: "SolidStart",    color: chalk.blueBright,       desc: "Fine-grained reactive UI framework",    value: "solid"        },
+];
+
+/**
+ * Prompts the user to select a frontend framework.
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[2/10]".
+ * @returns {Promise<{ frontend: string }>}
+ */
+export async function askFrontend(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { frontend } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "frontend",
+      message: chalk.bold(`${prefix}Select a frontend framework:`),
+      choices: FRONTEND_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`⚡ ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      pageSize: 10,
+      default: "react-router",
+    },
+  ]);
+
+  return { frontend };
+}

--- a/prompts/index.js
+++ b/prompts/index.js
@@ -1,0 +1,158 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+import boxen from "boxen";
+import { askLanguage } from "./language.js";
+import { askFrontend } from "./frontend.js";
+import { askBackend } from "./backend.js";
+import { askRuntime } from "./runtime.js";
+import { askDatabase } from "./database.js";
+import { askORM } from "./orm.js";
+import { askAPI } from "./api.js";
+import { askAuth } from "./auth.js";
+import { askAddons } from "./addons.js";
+
+const TOTAL_STEPS = 10;
+
+/**
+ * Builds a dim step label like "[3/10]" for prompt prefixes.
+ *
+ * @param {number} n - Current step.
+ * @returns {string}
+ */
+function step(n) {
+  return chalk.dim(`[${n}/${TOTAL_STEPS}]`);
+}
+
+/**
+ * Renders a styled confirmation box showing all selections at a glance.
+ *
+ * @param {object} config - Gathered config object.
+ */
+function showConfirmationSummary(config) {
+  const line = (icon, label, value, color = chalk.white) =>
+    value && value !== "none"
+      ? `${icon} ${chalk.bold(label + ":")}  ${color(value)}`
+      : null;
+
+  const lines = [
+    line("📖", "Language", config.language, chalk.yellowBright),
+    line("🎨", "Frontend", config.frontend, chalk.cyanBright),
+    line("⚙️ ", "Backend", config.backend, chalk.magentaBright),
+    line("⚡", "Runtime", config.runtime === "bun" ? "Bun" : "Node.js", chalk.greenBright),
+  ];
+
+  if (config.database.type !== "none") {
+    const dbVal = config.database.provider
+      ? `${config.database.type} ${chalk.gray("via")} ${config.database.provider}`
+      : config.database.type;
+    lines.push(`🗄️  ${chalk.bold("Database:")}  ${chalk.cyanBright(dbVal)}`);
+  }
+
+  lines.push(
+    line("🔗", "ORM", config.orm, chalk.greenBright),
+    line("🔌", "API", config.api, chalk.blueBright),
+    line("🔐", "Auth", config.auth, chalk.magentaBright),
+  );
+
+  if (config.addons.length > 0) {
+    lines.push(`🧩 ${chalk.bold("Add-ons:")}  ${chalk.yellow(config.addons.join(", "))}`);
+  }
+
+  console.log(
+    boxen(lines.filter(Boolean).join("\n"), {
+      padding: 1,
+      margin: { top: 1, bottom: 0, left: 0, right: 0 },
+      borderColor: "cyan",
+      borderStyle: "round",
+      title: chalk.cyanBright.bold("📋 Your Custom Stack"),
+      titleAlignment: "center",
+    })
+  );
+}
+
+/**
+ * Orchestrates all custom-stack prompts in the correct order, applying
+ * conditional logic (e.g. skip ORM when no DB, skip API type when no backend).
+ *
+ * Features step numbering, a language prompt, and a confirmation gate.
+ *
+ * @returns {Promise<{
+ *   language: string,
+ *   frontend: string,
+ *   backend: string,
+ *   runtime: string,
+ *   database: { type: string, provider: string },
+ *   orm: string,
+ *   api: string,
+ *   auth: string,
+ *   addons: string[]
+ * }>}
+ */
+export async function gatherCustomConfig() {
+  // This outer loop allows the user to re-do selections if they reject
+  // the confirmation prompt.
+  while (true) {
+    // 1. Language
+    const { language } = await askLanguage(step(1));
+
+    // 2. Frontend
+    const { frontend } = await askFrontend(step(2));
+
+    // 3. Backend
+    const { backend } = await askBackend(step(3));
+    if (backend === "none") {
+      console.log(chalk.yellow("   ⚠️  No backend selected — this will be a frontend-only project."));
+    }
+
+    // 4. Runtime
+    const { runtime } = await askRuntime(step(4));
+
+    // 5. Database (includes conditional provider/setup prompt)
+    const { database } = await askDatabase(step(5));
+
+    // 6. ORM — skip when no database is selected
+    let orm = "none";
+    if (database.type !== "none") {
+      const ormResult = await askORM(step(6));
+      orm = ormResult.orm;
+    } else {
+      console.log(chalk.gray(`   ${step(6)} ORM selection skipped ${chalk.dim("(no database)")}`));
+    }
+
+    // 7. API type — skip when no backend is selected
+    let api = "none";
+    if (backend !== "none") {
+      const apiResult = await askAPI(step(7));
+      api = apiResult.api;
+    } else {
+      console.log(chalk.gray(`   ${step(7)} API type selection skipped ${chalk.dim("(no backend)")}`));
+    }
+
+    // 8. Auth provider
+    const { auth } = await askAuth(step(8));
+
+    // 9. Add-ons (multi-select)
+    const { addons } = await askAddons(step(9));
+
+    const config = { language, frontend, backend, runtime, database, orm, api, auth, addons };
+
+    // 10. Confirmation
+    showConfirmationSummary(config);
+
+    const { confirmed } = await inquirer.prompt([
+      {
+        type: "confirm",
+        name: "confirmed",
+        message: chalk.bold(`${step(10)} Proceed with this configuration?`),
+        default: true,
+      },
+    ]);
+
+    if (confirmed) {
+      return config;
+    }
+
+    // User rejected — loop back and re-do selections
+    console.log(chalk.yellow("\n🔄 Let's try again!\n"));
+  }
+}

--- a/prompts/language.js
+++ b/prompts/language.js
@@ -1,0 +1,37 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * Language options for the project.
+ */
+const LANGUAGE_OPTIONS = [
+  { label: "TypeScript", color: chalk.blueBright, desc: "Type-safe JavaScript superset", value: "typescript" },
+  { label: "JavaScript", color: chalk.yellowBright, desc: "Classic dynamic scripting",     value: "javascript" },
+];
+
+/**
+ * Prompts the user to select a programming language.
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[1/9]".
+ * @returns {Promise<{ language: string }>}
+ */
+export async function askLanguage(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { language } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "language",
+      message: chalk.bold(`${prefix}Select a language:`),
+      choices: LANGUAGE_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`⚡ ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      default: "typescript",
+    },
+  ]);
+
+  return { language };
+}

--- a/prompts/orm.js
+++ b/prompts/orm.js
@@ -1,0 +1,39 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * ORM options available for selection.
+ */
+const ORM_OPTIONS = [
+  { label: "Drizzle", color: chalk.greenBright,    desc: "Type-safe SQL-first ORM",             value: "drizzle" },
+  { label: "Prisma",  color: chalk.magentaBright,  desc: "Next-gen Node.js & TypeScript ORM",   value: "prisma"  },
+  { label: "None",    color: chalk.gray,            desc: "No ORM",                              value: "none"    },
+];
+
+/**
+ * Prompts the user to select an ORM.
+ * Should be skipped when the database selection is "none".
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[6/10]".
+ * @returns {Promise<{ orm: string }>}
+ */
+export async function askORM(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { orm } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "orm",
+      message: chalk.bold(`${prefix}Select an ORM:`),
+      choices: ORM_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`${opt.value === "none" ? "◻" : "⚡"} ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      default: "drizzle",
+    },
+  ]);
+
+  return { orm };
+}

--- a/prompts/runtime.js
+++ b/prompts/runtime.js
@@ -1,0 +1,37 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+/**
+ * Runtime environment options.
+ */
+const RUNTIME_OPTIONS = [
+  { label: "Node.js", color: chalk.greenBright, desc: "The standard JavaScript runtime",        value: "node" },
+  { label: "Bun",     color: chalk.white,       desc: "Fast all-in-one JS runtime & toolkit",   value: "bun"  },
+];
+
+/**
+ * Prompts the user to select a runtime environment.
+ *
+ * @param {string} [stepLabel] - Optional step label prefix, e.g. "[4/10]".
+ * @returns {Promise<{ runtime: string }>}
+ */
+export async function askRuntime(stepLabel = "") {
+  const prefix = stepLabel ? `${stepLabel} ` : "";
+
+  const { runtime } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "runtime",
+      message: chalk.bold(`${prefix}Select a runtime environment:`),
+      choices: RUNTIME_OPTIONS.map((opt) => ({
+        name:
+          opt.color.bold(`⚡ ${opt.label}`) +
+          chalk.gray(` → ${opt.desc}`),
+        value: opt.value,
+      })),
+      default: "node",
+    },
+  ]);
+
+  return { runtime };
+}

--- a/utils/installer.js
+++ b/utils/installer.js
@@ -1,7 +1,200 @@
 import { execSync } from "child_process";
 import { logger } from "./logger.js";
+import { buildViteCommand, getInstallCommand, BADGE_CSS, BADGE_JSX } from "./shared.js";
 import path from "path";
 import fs from "fs";
+
+// ─── Shared Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Creates a Vite project using the correct package-manager command.
+ *
+ * @param {string} projectPath - Parent directory for the new project.
+ * @param {object} config - Project config (packageManager, language, etc.).
+ * @param {string} baseTemplate - Base Vite template name (e.g. "react", "vue").
+ * @param {string} [outputDir="client"] - Directory name for the scaffolded project.
+ */
+function createViteProject(projectPath, config, baseTemplate, outputDir = "client") {
+  const template =
+    config.language === "typescript" ? `${baseTemplate}-ts` : baseTemplate;
+  const cmd = buildViteCommand(config, template, outputDir);
+
+  execSync(cmd, { cwd: projectPath, stdio: "inherit", shell: true });
+}
+
+/**
+ * Injects the "Powered by Celtrix" badge into a React (JSX/TSX) project.
+ * Handles both JavaScript and TypeScript by detecting the file extension.
+ *
+ * @param {string} projectPath - Root project directory.
+ * @param {object} config - Project config.
+ */
+function injectReactBadge(projectPath, config) {
+  const ext = config.language === "typescript" ? "tsx" : "jsx";
+  const appPath = path.join(projectPath, "client", "src", `App.${ext}`);
+  const cssPath = path.join(projectPath, "client", "src", "index.css");
+
+  // --- Inject badge component ---
+  if (!fs.existsSync(appPath)) {
+    logger.warn(`⚠️ App.${ext} not found at ${appPath}, skipping badge injection`);
+    return;
+  }
+
+  let appContent;
+  try {
+    appContent = fs.readFileSync(appPath, "utf-8");
+  } catch (error) {
+    logger.error(`❌ Failed to read App.${ext}: ${error.message}`);
+    return;
+  }
+
+  const lines = appContent.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes("</>")) {
+      lines.splice(i, 0, BADGE_JSX);
+      break;
+    }
+  }
+
+  try {
+    fs.writeFileSync(appPath, lines.join("\n"), "utf-8");
+  } catch (error) {
+    logger.error(`❌ Failed to write App.${ext}: ${error.message}`);
+    return;
+  }
+
+  // --- Inject badge CSS ---
+  if (!fs.existsSync(cssPath)) {
+    logger.warn(`⚠️ index.css not found at ${cssPath}, skipping CSS injection`);
+  } else {
+    try {
+      fs.appendFileSync(cssPath, BADGE_CSS, "utf-8");
+    } catch (error) {
+      logger.error(`❌ Failed to append CSS: ${error.message}`);
+    }
+  }
+}
+
+/**
+ * Injects the "Powered by Celtrix" badge into a Vue project.
+ *
+ * @param {string} projectPath - Root project directory.
+ */
+function injectVueBadge(projectPath) {
+  const vuePath = path.join(
+    projectPath, "client", "src", "components", "HelloWorld.vue"
+  );
+
+  if (!fs.existsSync(vuePath)) {
+    logger.warn(`⚠️ HelloWorld.vue not found, skipping badge injection`);
+    return;
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(vuePath, "utf-8");
+  } catch (error) {
+    logger.error(`❌ Failed to read HelloWorld.vue: ${error.message}`);
+    return;
+  }
+
+  // Inject openCeltrix function into <script setup>
+  content = content.replace(
+    /<script setup lang="ts">([\s\S]*?)<\/script>/,
+    (match, p1) => {
+      if (!p1.includes("openCeltrix")) {
+        return `<script setup lang="ts">
+    ${p1.trim()}
+
+    const openCeltrix = () => {
+      window.open('https://github.com/celtrix-os/Celtrix', '_blank');
+    }
+    </script>`;
+      }
+      return match;
+    }
+  );
+
+  // Inject badge button after "read-the-docs" paragraph
+  content = content.replace(
+    /<p class="read-the-docs">Click on the Vite and Vue logos to learn more<\/p>/,
+    `<p class="read-the-docs">Click on the Vite and Vue logos to learn more</p>
+    <button className="powered-badge" @click="openCeltrix">Powered by <span className="celtrix">Celtrix</span></button>`
+  );
+
+  // Inject or replace scoped styles
+  const badgeStyles = `<style scoped>
+${BADGE_CSS}
+</style>`;
+
+  if (/<style scoped>[\s\S]*?<\/style>/.test(content)) {
+    content = content.replace(/<style scoped>[\s\S]*?<\/style>/, badgeStyles);
+  } else {
+    content += `\n\n${badgeStyles}`;
+  }
+
+  try {
+    fs.writeFileSync(vuePath, content, "utf-8");
+  } catch (error) {
+    logger.error(`❌ Failed to write HelloWorld.vue: ${error.message}`);
+  }
+}
+
+/**
+ * Patches a Vite config file to add the Tailwind CSS plugin.
+ *
+ * @param {string} viteConfigPath - Absolute path to vite.config.js/ts.
+ */
+function patchViteConfigWithTailwind(viteConfigPath) {
+  if (!fs.existsSync(viteConfigPath)) return;
+
+  let content = fs.readFileSync(viteConfigPath, "utf-8");
+
+  content = content.replace(
+    /import \{\s*defineConfig\s*\}\s*from\s*['"]vite['"]/,
+    `import { defineConfig } from 'vite'\nimport tailwindcss from '@tailwindcss/vite'`
+  );
+
+  content = content.replace(
+    /plugins:\s*\[([^\]]*)\]/,
+    (match, pluginsInside) => {
+      if (!pluginsInside.includes("tailwindcss()")) {
+        return `plugins: [${pluginsInside.trim()} , tailwindcss()]`;
+      }
+      return match;
+    }
+  );
+
+  fs.writeFileSync(viteConfigPath, content, "utf-8");
+}
+
+/**
+ * Ensures Tailwind's `@import 'tailwindcss'` directive is present in the
+ * project's main CSS file.
+ *
+ * @param {string} clientPath - Absolute path to the client directory.
+ */
+function ensureTailwindImport(clientPath) {
+  const candidates = [
+    path.join(clientPath, "src", "index.css"),
+    path.join(clientPath, "src", "style.css"),
+    path.join(clientPath, "src", "assets", "main.css"),
+  ];
+
+  const cssPath = candidates.find((p) => fs.existsSync(p));
+  if (!cssPath) return;
+
+  let cssContent = fs.readFileSync(cssPath, "utf-8");
+  if (cssContent.includes("@import 'tailwindcss'") || cssContent.includes('@import "tailwindcss"')) return;
+
+  cssContent = /:root/.test(cssContent)
+    ? cssContent.replace(/:root/, `@import 'tailwindcss';\n\n:root`)
+    : `@import 'tailwindcss';\n\n` + cssContent;
+
+  fs.writeFileSync(cssPath, cssContent, "utf-8");
+}
+
+// ─── Dependency Installation ─────────────────────────────────────────────────
 
 export function installDependencies(projectPath, config, projectName, server = true, dependencies = []) {
   try {
@@ -27,7 +220,8 @@ export function installDependencies(projectPath, config, projectName, server = t
 
     if (server && fs.existsSync(serverDir)) {
       logger.info("📦 Installing Backend dependencies...");
-      execSync(`${config.packageManager} ${config.packageManager == "npm" ? "install" : "add"} ` + dependencies.join(" "), { cwd: serverDir, stdio: "inherit", shell: true });
+      const installCmd = getInstallCommand(config.packageManager);
+      execSync(`${config.packageManager} ${installCmd} ` + dependencies.join(" "), { cwd: serverDir, stdio: "inherit", shell: true });
     }
 
     logger.info("✅ Dependencies installed successfully");
@@ -38,12 +232,12 @@ export function installDependencies(projectPath, config, projectName, server = t
   }
 }
 
+// ─── Stack Setup Functions ───────────────────────────────────────────────────
 
 export function angularSetup(projectPath, config, projectName, installDeps) {
   logger.info("⚡ Setting up Angular...");
 
   try {
-    // Create Angular project (no Tailwind)
     execSync(`npx -y @angular/cli new client --style=css --skip-git --skip-install`, {
       cwd: projectPath,
       stdio: "inherit",
@@ -64,7 +258,6 @@ export function angularTailwindSetup(projectPath, config, projectName) {
   logger.info("⚡ Setting up Angular + Tailwind...");
 
   try {
-    // 1. Create Angular project (inside projectPath)
     execSync(`npx -y @angular/cli new client --style css`, {
       cwd: projectPath,
       stdio: "inherit",
@@ -73,31 +266,21 @@ export function angularTailwindSetup(projectPath, config, projectName) {
 
     const clientPath = path.join(projectPath, "client");
 
-    // 2. Install Tailwind + PostCSS
-    execSync(`${config.packageManager} ${config.packageManager == "npm" ? "install" : "add"} tailwindcss @tailwindcss/postcss postcss --force`, {
+    const installCmd = getInstallCommand(config.packageManager);
+    execSync(`${config.packageManager} ${installCmd} tailwindcss @tailwindcss/postcss postcss --force`, {
       cwd: clientPath,
       stdio: "inherit",
       shell: true,
     });
 
-    // 3. Create tailwind.config.js
-    const tailwindConfigPath = path.join(clientPath, ".postcssrc.json");
-
     fs.writeFileSync(
-      tailwindConfigPath,
-      `{
-  "plugins": {
-    "@tailwindcss/postcss": {}
-  }
-}`
+      path.join(clientPath, ".postcssrc.json"),
+      `{\n  "plugins": {\n    "@tailwindcss/postcss": {}\n  }\n}`
     );
 
-    // 4. Update styles.css with Tailwind directives
-    const stylesPath = path.join(clientPath, "src/styles.css");
     fs.writeFileSync(
-      stylesPath,
+      path.join(clientPath, "src/styles.css"),
       `@import "tailwindcss";\n`
-
     );
 
     logger.info("✅ Angular + Tailwind setup completed!");
@@ -108,39 +291,22 @@ export function angularTailwindSetup(projectPath, config, projectName) {
   }
 }
 
-
 export function HonoReactSetup(projectPath, config, projectName, installDeps) {
-  logger.info("⚡ Setting up Hono+ React...");
+  logger.info("⚡ Setting up Hono + React...");
 
   try {
-    // 1. Create React project (inside projectPath)
-    if (config.language === "typescript") {
+    createViteProject(projectPath, config, "react");
 
-      execSync(`npm create vite@latest client -- --t react-ts --no-rolldown --no-interactive `, {
-        cwd: projectPath,
-        stdio: "inherit",
-        shell: true,
-      });
-    } else {
-      execSync(`npm create vite@latest client -- --t react --no-rolldown --no-interactive `, {
-        cwd: projectPath,
-        stdio: "inherit",
-        shell: true,
-      });
-
-    }
-
-    execSync(`npm create hono@latest server -- --template cloudflare-workers --pm npm `, {
+    execSync(`npm create hono@latest server -- --template cloudflare-workers --pm npm`, {
       cwd: projectPath,
       stdio: "inherit",
       shell: true,
     });
 
-    logger.info("Created Hono + React Project !");
+    logger.info("✅ Created Hono + React project!");
     serverAuthSetup(projectPath, config, projectName, installDeps);
-
   } catch (error) {
-    logger.error("❌ Failed to set up Hono + react Project using cli");
+    logger.error("❌ Failed to set up Hono + React project");
     throw error;
   }
 }
@@ -149,188 +315,15 @@ export function mernSetup(projectPath, config, projectName, installDeps) {
   logger.info("⚡ Setting up MERN...");
 
   try {
-    // 1. Create MERN project
-    if (config.language === "typescript") {
-
-      execSync(`${config.packageManager} create ${config.packageManager == "npm" ? "vite@latest" : "vite"} client ${config.packageManager == "npm" ? "--" : ""} --t react-ts --no-rolldown --no-interactive `, {
-        cwd: projectPath,
-        stdio: "inherit",
-        shell: true,
-      });
-    } else {
-      execSync(`${config.packageManager} create ${config.packageManager == "npm" ? "vite@latest" : "vite"} client ${config.packageManager == "npm" ? "--" : ""} --t react --no-rolldown --no-interactive `, {
-        cwd: projectPath,
-        stdio: "inherit",
-        shell: true,
-      });
-
-    }
-
-    if (config.language == 'javascript') {
-
-
-      const appJsxPath = path.join(projectPath, "client", "src", "App.jsx");
-      const appCssPath = path.join(projectPath, "client", "src", "index.css");
-
-      // Check if App.jsx exists before trying to read it
-      if (!fs.existsSync(appJsxPath)) {
-        logger.warn(`⚠️ App.jsx not found at ${appJsxPath}, skipping badge injection`);
-        return;
-      }
-
-      let appJsx;
-      try {
-        appJsx = fs.readFileSync(appJsxPath, "utf-8");
-      } catch (error) {
-        logger.error(`❌ Failed to read App.jsx: ${error.message}`);
-        return;
-      }
-
-      const lines = appJsx.split("\n");
-
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes("</>")) {
-          // inject badge right after opening fragment
-          lines.splice(i, 0, `  <button className="powered-badge" onClick={() => window.open('https://github.com/celtrix-os/Celtrix', '_blank')}>Powered by <span className="celtrix">Celtrix</span></button>`);
-          break;
-        }
-      }
-
-      try {
-        fs.writeFileSync(appJsxPath, lines.join("\n"), "utf-8");
-      } catch (error) {
-        logger.error(`❌ Failed to write App.jsx: ${error.message}`);
-        return;
-      }
-
-      // Append badge CSS styles
-      const badgeCSS = `
-    .powered-badge {
-      position: fixed;
-      bottom: 50%;
-      right: 1.5rem;
-      font-size: 1rem;
-      font-weight: 300;
-      background-color: black;
-      line-height: 1.5;
-      color: white;
-      padding: 0.5rem 1rem;
-      border-radius: 0.75rem;
-      box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1),
-      0 4px 6px -2px rgba(0,0,0,0.05);
-      opacity: 0.8;
-      transition: opacity 0.2s ease-in-out;
-    }
-      
-    .powered-badge:hover {
-      opacity: 1;
-    }
-      
-    .celtrix {
-      font-weight: 620;
-      font-size: 1.05rem;
-      color: #4ade80;
-      text-decoration: underline;
-    }
-    `;
-
-      // Check if CSS file exists before appending
-      if (!fs.existsSync(appCssPath)) {
-        logger.warn(`⚠️ index.css not found at ${appCssPath}, skipping CSS injection`);
-      } else {
-        try {
-          fs.appendFileSync(appCssPath, badgeCSS, "utf-8");
-        } catch (error) {
-          logger.error(`❌ Failed to append CSS: ${error.message}`);
-        }
-      }
-
-    }
-
-    if (config.language == "typescript") {
-      const appTsxPath = path.join(projectPath, "client", "src", "App.tsx");
-      const appCssPath = path.join(projectPath, "client", "src", "index.css");
-
-      // Check if App.tsx exists before trying to read it
-      if (!fs.existsSync(appTsxPath)) {
-        logger.warn(`⚠️ App.tsx not found at ${appTsxPath}, skipping badge injection`);
-        return;
-      }
-
-      let appTsx;
-      try {
-        appTsx = fs.readFileSync(appTsxPath, "utf-8");
-      } catch (error) {
-        logger.error(`❌ Failed to read App.tsx: ${error.message}`);
-        return;
-      }
-      const lines = appTsx.split("\n");
-
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes("</>")) {
-          // inject badge right after opening fragment
-          lines.splice(i, 0, `  <button className="powered-badge" onClick={() => window.open('https://github.com/celtrix-os/Celtrix', '_blank')}>Powered by <span className="celtrix">Celtrix</span></button>`);
-          break;
-        }
-      }
-
-      try {
-        fs.writeFileSync(appTsxPath, lines.join("\n"), "utf-8");
-      } catch (error) {
-        logger.error(`❌ Failed to write App.tsx: ${error.message}`);
-        return;
-      }
-
-      // Append badge CSS styles
-      const badgeCSS = `
-    .powered-badge {
-      position: fixed;
-      bottom: 50%;
-      right: 1.5rem;
-      font-size: 1rem;
-      font-weight: 300;
-      background-color: black;
-      line-height: 1.5;
-      color: white;
-      padding: 0.5rem 1rem;
-      border-radius: 0.75rem;
-      box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1),
-      0 4px 6px -2px rgba(0,0,0,0.05);
-      opacity: 0.8;
-      transition: opacity 0.2s ease-in-out;
-      }
-      
-    .powered-badge:hover {
-      opacity: 1;
-    }
-    
-    .celtrix {
-      font-weight: 620;
-      font-size: 1.05rem;
-      color: #4ade80;
-      text-decoration: underline;
-    }
-    `;
-
-      // Check if CSS file exists before appending
-      if (!fs.existsSync(appCssPath)) {
-        logger.warn(`⚠️ index.css not found at ${appCssPath}, skipping CSS injection`);
-      } else {
-        try {
-          fs.appendFileSync(appCssPath, badgeCSS, "utf-8");
-        } catch (error) {
-          logger.error(`❌ Failed to append CSS: ${error.message}`);
-        }
-      }
-
-    }
+    createViteProject(projectPath, config, "react");
+    injectReactBadge(projectPath, config);
 
     if (config.stack === "mern+tailwind+auth") {
       serverAuthSetup(projectPath, config, projectName, installDeps);
-    }
-    else if (config.stack === "mern") {
+    } else if (config.stack === "mern") {
       serverSetup(projectPath, config, projectName, installDeps);
     }
+
     logger.info("✅ MERN project created successfully!");
   } catch (error) {
     logger.error("❌ Failed to set up MERN");
@@ -340,145 +333,33 @@ export function mernSetup(projectPath, config, projectName, installDeps) {
 
 export function mernTailwindSetup(projectPath, config, projectName) {
   try {
-    execSync(`${config.packageManager} ${config.packageManager == "npm" ? "install" : "add"} tailwindcss @tailwindcss/vite`, { cwd: path.join(projectPath, "client") });
+    const clientPath = path.join(projectPath, "client");
+    const installCmd = getInstallCommand(config.packageManager);
+    execSync(`${config.packageManager} ${installCmd} tailwindcss @tailwindcss/vite`, { cwd: clientPath });
 
-    let isJs = config.language === 'javascript';
-    const viteConfigPath = isJs
-      ? path.join(projectPath, "client", "vite.config.js")
-      : path.join(projectPath, "client", "vite.config.ts");
-
-    let viteConfigContent = fs.readFileSync(viteConfigPath, "utf-8");
-
-    const indexCssPath = path.join(projectPath, "client", "src", "index.css")
-    let indexCssPathContent = fs.readFileSync(indexCssPath, "utf-8");
-
-    indexCssPathContent = indexCssPathContent.replace(
-      /:root/g,
-      "@import 'tailwindcss';\n\n:root"
+    const isJs = config.language === "javascript";
+    const viteConfigPath = path.join(
+      clientPath,
+      isJs ? "vite.config.js" : "vite.config.ts"
     );
 
+    patchViteConfigWithTailwind(viteConfigPath);
+    ensureTailwindImport(clientPath);
 
-    fs.writeFileSync(indexCssPath, indexCssPathContent)
-
-    // Add tailwindcss import
-    viteConfigContent = viteConfigContent.replace(
-      /import \{ defineConfig \} from 'vite'/,
-      "import { defineConfig } from 'vite'\nimport tailwindcss from '@tailwindcss/vite'"
-    );
-
-    // Add tailwindcss() to plugins
-    viteConfigContent = viteConfigContent.replace(
-      /plugins:\s*\[([^\]]*)\]/,
-      (match, pluginsInside) => {
-        if (!pluginsInside.includes("tailwindcss()")) {
-          return `plugins: [${pluginsInside.trim()} , tailwindcss()]`;
-        }
-        return match; // avoid duplicate insert
-      }
-    );
-
-    fs.writeFileSync(viteConfigPath, viteConfigContent);
-
-    console.log("✅ TailwindCSS added to Vite config");
+    logger.info("✅ TailwindCSS added to Vite config");
   } catch (err) {
-    console.error("❌ Failed to setup Tailwind:", err.message);
+    logger.error(`❌ Failed to setup Tailwind: ${err.message}`);
   }
 }
-
 
 export function mevnSetup(projectPath, config, projectName, installDeps) {
   try {
     logger.info("⚡ Setting up MEVN...");
-    if (config.language == 'javascript') {
-      execSync(`${config.packageManager} create ${config.packageManager == "npm" ? "vite@latest" : "vite"} client ${config.packageManager == "npm" ? "--" : ""} --t vue --no-rolldown --no-interactive`, { cwd: projectPath, stdio: "inherit", shell: true });
-
-
-    }
-    else {
-      execSync(`${config.packageManager} create ${config.packageManager == "npm" ? "vite@latest" : "vite"} client ${config.packageManager == "npm" ? "--" : ""} --t vue-ts --no-rolldown --no-interactive`, { cwd: projectPath, stdio: "inherit", shell: true });
-    }
-
-
-    const vueJsPath = path.join(projectPath, "client", "src", "components", "HelloWorld.vue");
-    const scriptPath = path.join(projectPath, "client", "src", "components", "HelloWorld.vue");
-
-    let scriptPathContent = fs.readFileSync(scriptPath, "utf-8");
-
-    // Replace or inject content inside <script setup lang="ts">
-    scriptPathContent = scriptPathContent.replace(
-      /<script setup lang="ts">([\s\S]*?)<\/script>/,
-      (match, p1) => {
-        // Keep existing content and add openCeltrix function if not present
-        if (!p1.includes("openCeltrix")) {
-          return `<script setup lang="ts">
-    ${p1.trim()}
-
-      const openCeltrix = () => {
-        window.open('https://github.com/celtrix-os/Celtrix', '_blank');
-      }
-      </script>`;
-        }
-        return match;
-      }
-    );
-
-    fs.writeFileSync(scriptPath, scriptPathContent, "utf-8");
-
-    let vueJsPathContent = fs.readFileSync(vueJsPath, "utf-8");
-
-    vueJsPathContent = vueJsPathContent.replace(
-      /<p class="read-the-docs">Click on the Vite and Vue logos to learn more<\/p>/,
-      `<p class="read-the-docs">Click on the Vite and Vue logos to learn more</p>
-    <button className="powered-badge" @click="openCeltrix">Powered by <span className="celtrix">Celtrix</span></button>`
-    );
-
-    fs.writeFileSync(vueJsPath, vueJsPathContent, "utf-8");
-
-    // Replace <style> block (or append if missing)~
-    const newStyles = `<style scoped>
-    .powered-badge {
-      position: fixed;
-      bottom: 50%;
-      right: 1.5rem;
-      font-size: 1rem;
-      font-weight: 300;
-      background-color: black;
-      line-height: 1.5;
-      color: white;
-      padding: 0.5rem 1rem;
-      border-radius: 0.75rem;
-      box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1),
-      0 4px 6px -2px rgba(0,0,0,0.05);
-      opacity: 0.8;
-      transition: opacity 0.2s ease-in-out;
-      }
-      
-      .powered-badge:hover {
-      opacity: 1;
-      }
-      
-      .celtrix {
-        font-weight: 620;
-        font-size: 1.05rem;
-        color: #4ade80;
-        text-decoration: underline;
-        }
-    </style>`;
-
-    if (/<style scoped>[\s\S]*?<\/style>/.test(vueJsPathContent)) {
-      vueJsPathContent = vueJsPathContent.replace(
-        /<style scoped>[\s\S]*?<\/style>/,
-        newStyles
-      );
-    } else {
-      vueJsPathContent += `\n\n${newStyles}`;
-    }
-
-    fs.writeFileSync(vueJsPath, vueJsPathContent, "utf-8");
+    createViteProject(projectPath, config, "vue");
+    injectVueBadge(projectPath);
 
     logger.info("✅ MEVN project created successfully!");
     serverSetup(projectPath, config, projectName, installDeps);
-
   } catch (error) {
     logger.error("❌ Failed to set up MEVN");
     throw error;
@@ -489,191 +370,72 @@ export function mevnTailwindAuthSetup(projectPath, config, projectName, installD
   logger.info("⚡ Setting up MEVN + Tailwind + Auth...");
 
   try {
-    // 1. Create Vue client with Vite (js / ts)
-    if (config.language === 'javascript') {
-
-      execSync(`${config.packageManager} create ${config.packageManager == "npm" ? "vite@latest" : "vite"} client ${config.packageManager == "npm" ? "--" : ""} --t vue --no-rolldown --no-interactive`, {
-        cwd: projectPath,
-        stdio: "inherit",
-        shell: true,
-      });
-    }
-
-    else {
-      execSync(`${config.packageManager} create ${config.packageManager == "npm" ? "vite@latest" : "vite"} client ${config.packageManager == "npm" ? "--" : ""} --t vue-ts --no-rolldown --no-interactive`, {
-        cwd: projectPath,
-        stdio: "inherit",
-        shell: true,
-      });
-    }
+    createViteProject(projectPath, config, "vue");
 
     const clientPath = path.join(projectPath, "client");
 
-    // 2. Install Tailwind plugin for Vite in client
-    execSync(`${config.packageManager} ${config.packageManager == "npm" ? "install" : "add"} tailwindcss @tailwindcss/vite`, {
+    // Install Tailwind plugin for Vite
+    const installCmd = getInstallCommand(config.packageManager);
+    execSync(`${config.packageManager} ${installCmd} tailwindcss @tailwindcss/vite`, {
       cwd: clientPath,
       stdio: "inherit",
       shell: true,
     });
 
-    // 3. Patch Vite config (handle .js / .ts like mernTailwindSetup)
+    // Patch Vite config
     const isJs = config.language === "javascript";
-    const viteConfigPath = isJs
-      ? path.join(clientPath, "vite.config.js")
-      : path.join(clientPath, "vite.config.ts");
-
-    if (fs.existsSync(viteConfigPath)) {
-      let viteConfigContent = fs.readFileSync(viteConfigPath, "utf-8");
-
-      viteConfigContent = viteConfigContent.replace(
-        /import \{\s*defineConfig\s*\}\s*from\s*['"]vite['"]/,
-        `import { defineConfig } from 'vite'\nimport tailwindcss from '@tailwindcss/vite'`
-      );
-
-      viteConfigContent = viteConfigContent.replace(
-        /plugins:\s*\[([^\]]*)\]/,
-        (match, pluginsInside) => {
-          if (!pluginsInside.includes("tailwindcss()")) {
-            return `plugins: [${pluginsInside.trim()} , tailwindcss()]`;
-          }
-          return match;
-        }
-      );
-
-      fs.writeFileSync(viteConfigPath, viteConfigContent, "utf-8");
-    }
-
-    // 4. Ensure Tailwind import exists in client CSS (try common filenames)
-    const possibleCssPaths = [
-      path.join(clientPath, "src", "index.css"),
-      path.join(clientPath, "src", "style.css"),
-      path.join(clientPath, "src", "assets", "main.css"),
-    ];
-    const cssPath = possibleCssPaths.find((p) => fs.existsSync(p));
-    if (cssPath) {
-      let cssContent = fs.readFileSync(cssPath, "utf-8");
-      if (!cssContent.includes("@import 'tailwindcss'") && !cssContent.includes('@import "tailwindcss"')) {
-        // try to place import before :root or at top
-        if (/:root/.test(cssContent)) {
-          cssContent = cssContent.replace(/:root/, `@import 'tailwindcss';\n\n:root`);
-        } else {
-          cssContent = `@import 'tailwindcss';\n\n` + cssContent;
-        }
-        fs.writeFileSync(cssPath, cssContent, "utf-8");
-      }
-    }
-
-    const vueJsPath = path.join(projectPath, "client", "src", "components", "HelloWorld.vue");
-    const scriptPath = path.join(projectPath, "client", "src", "components", "HelloWorld.vue");
-
-    // Check if Vue component exists before modifying
-    if (!fs.existsSync(scriptPath)) {
-      logger.warn(`⚠️ Vue component not found at ${scriptPath}, skipping badge injection`);
-      return;
-    }
-
-    let scriptPathContent;
-    try {
-      scriptPathContent = fs.readFileSync(scriptPath, "utf-8");
-    } catch (error) {
-      logger.error(`❌ Failed to read Vue component: ${error.message}`);
-      return;
-    }
-
-    // Replace or inject content inside <script setup lang="ts">
-    scriptPathContent = scriptPathContent.replace(
-      /<script setup lang="ts">([\s\S]*?)<\/script>/,
-      (match, p1) => {
-        // Keep existing content and add openCeltrix function if not present
-        if (!p1.includes("openCeltrix")) {
-          return `<script setup lang="ts">
-    ${p1.trim()}
-
-      const openCeltrix = () => {
-        window.open('https://github.com/celtrix-os/Celtrix', '_blank');
-      }
-      </script>`;
-        }
-        return match;
-      }
+    patchViteConfigWithTailwind(
+      path.join(clientPath, isJs ? "vite.config.js" : "vite.config.ts")
     );
 
-    fs.writeFileSync(scriptPath, scriptPathContent, "utf-8");
+    // Ensure Tailwind import in CSS
+    ensureTailwindImport(clientPath);
 
+    // Inject Vue badge
+    injectVueBadge(projectPath);
 
-    let vuejsPathContent = fs.readFileSync(vueJsPath, "utf-8");
-    vuejsPathContent = vuejsPathContent.replace(
-      /<p class="read-the-docs">Click on the Vite and Vue logos to learn more<\/p>/,
-      `<p class="read-the-docs">Click on the Vite and Vue logos to learn more</p>
-       <button
-    @click="openCeltrix"
-    class="fixed bottom-1/2 right-6 text-base font-light bg-black-500 text-white px-4 py-2 rounded-xl shadow-lg shadow-black/20 hover:opacity-100 transition-opacity duration-200 leading-relaxed"
-  >
-    Powered by
-    <span class="font-semibold text-[#4ade80] underline text-[1.05rem] ml-1">
-      Celtrix
-    </span>
-  </button>
-`
-    );
-    fs.writeFileSync(vueJsPath, vuejsPathContent, "utf-8");
-
-    logger.info("MEVN + Tailwind + Auth setup completed!");
-
+    logger.info("✅ MEVN + Tailwind + Auth setup completed!");
     serverAuthSetup(projectPath, config, projectName, installDeps);
   } catch (error) {
-    logger.error("Failed to set up MEVN + Tailwind + Auth");
+    logger.error("❌ Failed to set up MEVN + Tailwind + Auth");
     throw error;
   }
 }
 
 export function nextSetup(projectPath, config, projectName) {
   try {
-    // next command based on package manager
     function nextCommand() {
       switch (config.packageManager) {
-        case "npm":
-          return "npx create-next-app@latest";
-        case "pnpm":
-          return "pnpm dlx create-next-app@latest";
-        case "yarn":
-          return "yarn dlx create-next-app@latest";
-        case "bun":
-          return "bunx create-next-app@latest";
-        default:
-          return "npx create-next-app@latest";  
+        case "npm":   return "npx create-next-app@latest";
+        case "pnpm":  return "pnpm dlx create-next-app@latest";
+        case "yarn":  return "yarn dlx create-next-app@latest";
+        case "bun":   return "bunx create-next-app@latest";
+        default:      return "npx create-next-app@latest";
       }
     }
+
     if (config.language === "typescript") {
-      console.log("⚡ Setting up Next.js with TypeScript...");
-      execSync(`${nextCommand()} . \
-            --typescript \
-            --eslint \
-            --tailwind \
-            --src-dir \
-            --app \
-            --no-turbo \
-            --import-alias="@/*" \
-            --yes`, 
-      {
+      logger.info("⚡ Setting up Next.js with TypeScript...");
+      execSync(`${nextCommand()} . --typescript --eslint --tailwind --src-dir --app --no-turbo --import-alias="@/*" --yes`, {
         cwd: projectPath,
         stdio: "inherit",
-        shell: true
+        shell: true,
       });
     } else if (config.language === "javascript") {
       logger.info("⚡ Setting up Next.js with JavaScript...");
       execSync(`${nextCommand()} . --eslint --tailwind --src-dir --app --turbo --import-alias @/* --yes`, {
         cwd: projectPath,
         stdio: "inherit",
-        shell: true
+        shell: true,
       });
     } else {
       throw new Error("Invalid language option. Choose 'javascript' or 'typescript'.");
     }
 
-    console.log("✅ Next.js project setup completed!");
+    logger.info("✅ Next.js project setup completed!");
   } catch (err) {
-    console.error("❌ Error setting up Next.js:", err);
+    logger.error(`❌ Error setting up Next.js: ${err.message}`);
+    throw err;
   }
 }
 
@@ -681,22 +443,21 @@ export function serverSetup(projectPath, config, projectName, installDeps) {
   try {
     const serverDir = path.join(projectPath, "server");
 
-    // Create server directory if it doesn't exist
     if (!fs.existsSync(serverDir)) {
       fs.mkdirSync(serverDir, { recursive: true });
     }
 
-    // Initialize package.json
-    execSync('npm init -y', {
+    execSync("npm init -y", {
       cwd: serverDir,
-      stdio: 'ignore',  // Suppress output
-      shell: true
+      stdio: "ignore",
+      shell: true,
     });
 
     if (installDeps) {
-      installDependencies(projectPath, config, projectName, true, ["express", "dotenv", "mongoose", "nodemon", "cors", "helmet", "express-rate-limit"])
+      installDependencies(projectPath, config, projectName, true, [
+        "express", "dotenv", "mongoose", "nodemon", "cors", "helmet", "express-rate-limit",
+      ]);
     }
-
   } catch (error) {
     logger.error("❌ Failed to set up server");
     throw error;
@@ -707,26 +468,26 @@ export function serverAuthSetup(projectPath, config, projectName, installDeps) {
   try {
     const serverDir = path.join(projectPath, "server");
 
-    // Create server directory if it doesn't exist
     if (!fs.existsSync(serverDir)) {
       fs.mkdirSync(serverDir, { recursive: true });
     }
 
-    // Initialize package.json
     try {
-      execSync('npm init -y', {
+      execSync("npm init -y", {
         cwd: serverDir,
-        stdio: 'ignore',  // Suppress output
-        shell: true
+        stdio: "ignore",
+        shell: true,
       });
-    } catch (error) {
-      logger.info("✅ Server directory created successfully!");
+    } catch {
+      logger.debug("npm init -y failed (likely already initialized)");
     }
 
     if (installDeps) {
-      installDependencies(projectPath, config, projectName, true, ["bcrypt", "jsonwebtoken", "cookie-parser", "dotenv", "express", "helmet", "mongoose", "cors", "nodemon", "morgan"])
+      installDependencies(projectPath, config, projectName, true, [
+        "bcrypt", "jsonwebtoken", "cookie-parser", "dotenv", "express",
+        "helmet", "mongoose", "cors", "nodemon", "morgan",
+      ]);
     }
-
   } catch (error) {
     logger.error("❌ Failed to set up server auth");
     throw error;

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,8 +1,34 @@
 import chalk from "chalk";
 
+const isVerbose =
+  process.argv.includes("--verbose") || process.env.DEBUG === "celtrix";
+
 export const logger = {
   info: (msg) => console.log(chalk.blue(msg)),
   success: (msg) => console.log(chalk.green(msg)),
   warn: (msg) => console.log(chalk.yellow(msg)),
   error: (msg) => console.log(chalk.red(msg)),
+
+  /**
+   * Prints a debug message — only visible with --verbose flag or DEBUG=celtrix.
+   *
+   * @param {string} msg
+   */
+  debug: (msg) => {
+    if (isVerbose) {
+      console.log(chalk.gray(`[debug] ${msg}`));
+    }
+  },
+
+  /**
+   * Prints a step progress label:  [n/total] message
+   *
+   * @param {number} current - Current step number.
+   * @param {number} total - Total number of steps.
+   * @param {string} msg - Description of the step.
+   */
+  step: (current, total, msg) => {
+    const label = chalk.dim(`[${current}/${total}]`);
+    console.log(`\n${label} ${chalk.bold(msg)}`);
+  },
 };

--- a/utils/project.js
+++ b/utils/project.js
@@ -4,8 +4,121 @@ import chalk from "chalk";
 import boxen from "boxen";
 import { logger } from "./logger.js";
 import { copyTemplates } from "./templateManager.js";
-import { HonoReactSetup,mernTailwindSetup, installDependencies, mernSetup, serverAuthSetup, serverSetup, mevnSetup, mevnTailwindAuthSetup, nextSetup } from "./installer.js";
+import { HonoReactSetup, mernTailwindSetup, installDependencies, mernSetup, serverAuthSetup, serverSetup, mevnSetup, mevnTailwindAuthSetup, nextSetup } from "./installer.js";
 import { angularSetup, angularTailwindSetup } from "./installer.js";
+
+/**
+ * Generates starter files for a custom-stack project so the user doesn't
+ * end up with just a JSON config file.
+ *
+ * @param {string} projectPath - Absolute path to the project directory.
+ * @param {string} projectName - Project name.
+ * @param {object} config - Full custom-stack config.
+ */
+function bootstrapCustomProject(projectPath, projectName, config) {
+  // ── README.md ──
+  const readmeLines = [
+    `# ${projectName}`,
+    "",
+    `> Bootstrapped with [Celtrix](https://github.com/celtrix-os/Celtrix) — Custom Stack`,
+    "",
+    "## Tech Stack",
+    "",
+    `| Layer | Choice |`,
+    `|-------|--------|`,
+    `| Language | ${config.language} |`,
+    `| Frontend | ${config.frontend} |`,
+    `| Backend | ${config.backend} |`,
+    `| Runtime | ${config.runtime === "bun" ? "Bun" : "Node.js"} |`,
+  ];
+
+  if (config.database && config.database.type !== "none") {
+    readmeLines.push(`| Database | ${config.database.type}${config.database.provider ? ` (${config.database.provider})` : ""} |`);
+  }
+  if (config.orm && config.orm !== "none") readmeLines.push(`| ORM | ${config.orm} |`);
+  if (config.api && config.api !== "none") readmeLines.push(`| API | ${config.api} |`);
+  if (config.auth && config.auth !== "none") readmeLines.push(`| Auth | ${config.auth} |`);
+  if (config.addons && config.addons.length > 0) readmeLines.push(`| Add-ons | ${config.addons.join(", ")} |`);
+
+  readmeLines.push(
+    "",
+    "## Getting Started",
+    "",
+    "```bash",
+    `cd ${projectName}`,
+    `${config.packageManager} install`,
+    `${config.packageManager === "npm" ? "npm run dev" : `${config.packageManager} run dev`}`,
+    "```",
+    "",
+    "## Configuration",
+    "",
+    "Your full stack configuration is saved in `celtrix.config.json`.",
+    "",
+    "---",
+    "",
+    "*Made with ❤️ by [Celtrix](https://github.com/celtrix-os/Celtrix)*",
+  );
+
+  fs.writeFileSync(path.join(projectPath, "README.md"), readmeLines.join("\n"), "utf-8");
+
+  // ── .gitignore ──
+  const gitignoreContent = [
+    "node_modules/",
+    "dist/",
+    "build/",
+    ".env",
+    ".env.local",
+    ".env.*.local",
+    "*.log",
+    "npm-debug.log*",
+    ".DS_Store",
+    "Thumbs.db",
+    ".vscode/",
+    ".idea/",
+    "coverage/",
+    ".nyc_output/",
+  ].join("\n");
+
+  fs.writeFileSync(path.join(projectPath, ".gitignore"), gitignoreContent, "utf-8");
+
+  // ── package.json ──
+  const pkgJson = {
+    name: projectName,
+    version: "0.1.0",
+    private: true,
+    type: "module",
+    scripts: {
+      dev: "echo \"Configure your dev script\"",
+      build: "echo \"Configure your build script\"",
+    },
+  };
+
+  fs.writeJsonSync(path.join(projectPath, "package.json"), pkgJson, { spaces: 2 });
+
+  // ── .env.example (conditional) ──
+  const envLines = [];
+  if (config.database && config.database.type !== "none") {
+    envLines.push(`# ${config.database.type.toUpperCase()} connection`);
+    envLines.push(`DATABASE_URL=""`);
+  }
+  if (config.auth && config.auth !== "none") {
+    envLines.push("");
+    envLines.push(`# ${config.auth} auth`);
+    if (config.auth === "clerk") {
+      envLines.push(`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=""`);
+      envLines.push(`CLERK_SECRET_KEY=""`);
+    } else if (config.auth === "better-auth") {
+      envLines.push(`AUTH_SECRET=""`);
+    }
+  }
+
+  if (envLines.length > 0) {
+    fs.writeFileSync(path.join(projectPath, ".env.example"), envLines.join("\n") + "\n", "utf-8");
+  }
+
+  // ── celtrix.config.json ──
+  fs.writeJsonSync(path.join(projectPath, "celtrix.config.json"), config, { spaces: 2 });
+}
 
 export async function setupProject(projectName, config, installDeps) {
   const projectPath = path.join(process.cwd(), projectName);
@@ -18,15 +131,35 @@ export async function setupProject(projectName, config, installDeps) {
   fs.mkdirSync(projectPath);
 
   // --- Pretty Project Config (Boxed) ---
-  const configText = `
-    ${chalk.bold("🌐 Stack:")}  ${chalk.green(config.stack)}
-    ${chalk.bold("📦 Project Name:")}  ${chalk.blue(projectName)}
-    ${chalk.bold("📖 Language:")}  ${chalk.red(config.language)}
-    ${chalk.bold("📦 Package Manager")}  ${chalk.magenta(config.packageManager)}
-    `;
+  const isCustom = config.stack === "custom";
+
+  const configLines = [
+    `${chalk.bold("🌐 Stack:")}  ${chalk.green(isCustom ? "Custom" : config.stack)}`,
+    `${chalk.bold("📦 Project Name:")}  ${chalk.blue(projectName)}`,
+  ];
+
+  if (isCustom) {
+    configLines.push(`${chalk.bold("📖 Language:")}  ${chalk.yellowBright(config.language)}`);
+    if (config.frontend)                            configLines.push(`${chalk.bold("🎨 Frontend:")}  ${chalk.cyanBright(config.frontend)}`);
+    if (config.backend && config.backend !== "none") configLines.push(`${chalk.bold("⚙️  Backend:")}  ${chalk.magentaBright(config.backend)}`);
+    if (config.database && config.database.type !== "none") {
+      configLines.push(`${chalk.bold("🗄️  Database:")}  ${chalk.cyanBright(config.database.type)}${config.database.provider ? chalk.gray(" via ") + chalk.white(config.database.provider) : ""}`);
+    }
+    if (config.orm && config.orm !== "none")         configLines.push(`${chalk.bold("🔗 ORM:")}  ${chalk.greenBright(config.orm)}`);
+    if (config.api && config.api !== "none")         configLines.push(`${chalk.bold("🔌 API:")}  ${chalk.blueBright(config.api)}`);
+    if (config.auth && config.auth !== "none")       configLines.push(`${chalk.bold("🔐 Auth:")}  ${chalk.magentaBright(config.auth)}`);
+    if (config.addons && config.addons.length > 0)   configLines.push(`${chalk.bold("🧩 Add-ons:")}  ${chalk.yellow(config.addons.join(", "))}`);
+  } else {
+    configLines.push(`${chalk.bold("📖 Language:")}  ${chalk.red(config.language)}`);
+  }
+
+  configLines.push(
+    `${chalk.bold("⚡ Runtime:")}  ${config.runtime === 'bun' ? chalk.white('Bun') : chalk.greenBright('Node.js')}`,
+    `${chalk.bold("📦 Package Manager:")}  ${chalk.magenta(config.packageManager)}`,
+  );
 
   console.log(
-    boxen(configText, {
+    boxen(configLines.join("\n"), {
       padding: 1,
       margin: 1,
       borderColor: "cyan",
@@ -38,108 +171,118 @@ export async function setupProject(projectName, config, installDeps) {
 
   // --- Copy & Install ---
 
+  try {
+    if (isCustom) {
+      logger.info("📋 Bootstrapping custom stack project...");
+      bootstrapCustomProject(projectPath, projectName, config);
+      logger.success(`✅ Project scaffolded with README, .gitignore, package.json, and config`);
+    }
 
-  if (config.stack === "mern") {
-    mernSetup(projectPath, config, projectName, installDeps);
-    copyTemplates(projectPath, config);
-    if (installDeps) installDependencies(projectPath, config, projectName, false, [])
-  }
+    else if (config.stack === "mern") {
+      mernSetup(projectPath, config, projectName, installDeps);
+      copyTemplates(projectPath, config);
+      if (installDeps) installDependencies(projectPath, config, projectName, false, []);
+    }
 
-  else if (config.stack === 'mevn') {
-    mevnSetup(projectPath, config, projectName, installDeps)
-    copyTemplates(projectPath, config)
-    if (installDeps) installDependencies(projectPath, config, projectName, false, [])
-  }
+    else if (config.stack === 'mevn') {
+      mevnSetup(projectPath, config, projectName, installDeps);
+      copyTemplates(projectPath, config);
+      if (installDeps) installDependencies(projectPath, config, projectName, false, []);
+    }
 
-  else if (config.stack === "mean") {
-    angularSetup(projectPath, config, projectName, installDeps);
-    copyTemplates(projectPath, config);
-    if (installDeps) installDependencies(projectPath, config, projectName);
-  }
+    else if (config.stack === "mean") {
+      angularSetup(projectPath, config, projectName, installDeps);
+      copyTemplates(projectPath, config);
+      if (installDeps) installDependencies(projectPath, config, projectName);
+    }
 
-  else if (config.stack === "mern+tailwind+auth") {
-    mernSetup(projectPath, config, projectName, installDeps);
-    copyTemplates(projectPath, config);
-    mernTailwindSetup(projectPath, config, projectName);
-    serverAuthSetup(projectPath, config, projectName, installDeps);
-  }
+    else if (config.stack === "mern+tailwind+auth") {
+      mernSetup(projectPath, config, projectName, installDeps);
+      copyTemplates(projectPath, config);
+      mernTailwindSetup(projectPath, config, projectName);
+      serverAuthSetup(projectPath, config, projectName, installDeps);
+    }
 
-  else if (config.stack === 'mevn+tailwind+auth') {
-    mevnTailwindAuthSetup(projectPath, config, projectName, installDeps);
-    copyTemplates(projectPath, config);
-    serverAuthSetup(projectPath, config, projectName, installDeps)
-  }
+    else if (config.stack === 'mevn+tailwind+auth') {
+      mevnTailwindAuthSetup(projectPath, config, projectName, installDeps);
+      copyTemplates(projectPath, config);
+      serverAuthSetup(projectPath, config, projectName, installDeps);
+    }
 
-  else if (config.stack === "mean+tailwind+auth") {
-    angularTailwindSetup(projectPath, config, projectName);
-    copyTemplates(projectPath, config);
-    if (installDeps) installDependencies(projectPath, config, projectName);
-    serverAuthSetup(projectPath, config, projectName, installDeps);
-  }
+    else if (config.stack === "mean+tailwind+auth") {
+      angularTailwindSetup(projectPath, config, projectName);
+      copyTemplates(projectPath, config);
+      if (installDeps) installDependencies(projectPath, config, projectName);
+      serverAuthSetup(projectPath, config, projectName, installDeps);
+    }
 
+    else if (config.stack === "react+tailwind+firebase") {
+      copyTemplates(projectPath, config);
+      if (installDeps) installDependencies(projectPath, config, projectName);
+    }
 
-  else if (config.stack === "react+tailwind+firebase") {
-    copyTemplates(projectPath, config);
-    if (installDeps) installDependencies(projectPath, config, projectName);
-  }
-
-
-  else if (config.stack === "hono") {
-    try {
+    else if (config.stack === "hono") {
       HonoReactSetup(projectPath, config, projectName, installDeps);
       copyTemplates(projectPath, config);
       if (installDeps) installDependencies(projectPath, config, projectName, false);
     }
-    catch {
-      copyTemplates(projectPath, config);
-    }
-  }
 
-  else if (config.stack === 'nextjs') {
-    try {
-      nextSetup(projectPath,config,projectName);
-      copyTemplates(projectPath,config)
+    else if (config.stack === 'nextjs') {
+      nextSetup(projectPath, config, projectName);
+      copyTemplates(projectPath, config);
       logger.info("✅ Next.js project created successfully!");
-    } catch (error) {
-      logger.error("❌ Failed to set up Next.js");
-      logger.error(error.message);
-      throw error;
     }
+  } catch (error) {
+    // Clean up the created directory on failure
+    logger.error(`❌ Scaffolding failed: ${error.message}`);
+    logger.debug(`Cleaning up ${projectPath}...`);
+    try {
+      fs.removeSync(projectPath);
+      logger.debug("Cleanup complete.");
+    } catch {
+      logger.debug("Cleanup failed — directory may need manual removal.");
+    }
+    throw error;
   }
 
   // --- Success + Next Steps ---
-  console.log(chalk.gray("-------------------------------------------"))
+  console.log(chalk.gray("-------------------------------------------"));
   console.log(`${chalk.greenBright(`✅ Project ${chalk.bold.yellow(`${projectName}`)} created successfully! 🎉`)}`);
-  console.log(chalk.gray("-------------------------------------------"))
+  console.log(chalk.gray("-------------------------------------------"));
   console.log(chalk.cyan("👉 Next Steps:\n"));
 
   // Provide package-manager commands for dev/start
   const cmd = (script) => {
+    const useBunRuntime = config.runtime === 'bun';
     switch (config.packageManager) {
       case "yarn":
-        return `yarn ${script == "dev" ? "dev" : "node server.js"}`;
+        return `yarn ${script === "dev" ? "dev" : (useBunRuntime ? "bun server.js" : "node server.js")}`;
       case "pnpm":
-        // pnpm supports both `pnpm run <script>` and `pnpm <script>`. Use run for clarity
-        return script === "dev" ? "pnpm run dev" : "node server.js";
+        return script === "dev" ? "pnpm run dev" : (useBunRuntime ? "bun server.js" : "node server.js");
       case "bun":
-        // use `bun run <script>` for consistency
-        return `bun ${script == "dev" ? "run dev" : "server.js"}`;
+        return `bun ${script === "dev" ? "run dev" : "server.js"}`;
       case "npm":
       default:
-        return script === "dev" ? "npm run dev" : "npm start";
+        return script === "dev" ? "npm run dev" : (useBunRuntime ? "bun server.js" : "npm start");
     }
   };
 
-  if (config.stack === "mean" || config.stack === "mean+tailwind+auth") {
+  if (isCustom) {
+    console.log(`   ${chalk.yellow("cd")} ${projectName} && ${chalk.green(cmd("dev"))}`);
+    if (config.database && config.database.type !== "none") {
+      console.log(`   ${chalk.gray("📝 Configure your database connection in .env (see .env.example)")}`);
+    }
+    if (config.auth && config.auth !== "none") {
+      console.log(`   ${chalk.gray(`📝 Configure your ${config.auth} credentials in .env`)}`);
+    }
+  } else if (config.stack === "mean" || config.stack === "mean+tailwind+auth") {
     console.log(`   ${chalk.yellow("cd")} ${projectName}/client && ${chalk.green(cmd("start"))}`);
     console.log(`   ${chalk.yellow("cd")} ${projectName}/server && ${chalk.green(cmd("start"))}`);
   } else if (config.stack === "nextjs") {
     console.log(`   ${chalk.yellow("cd")} ${projectName} && ${chalk.green(cmd("dev"))}`);
-
   } else if (config.stack === "react+tailwind+firebase") {
     console.log(`   ${chalk.yellow("cd")} ${projectName}/client && ${chalk.green(cmd("dev"))}`);
     console.log(`   ${chalk.gray("📝 Don't forget to configure your Firebase project in .env file!")}`);
-
   } else if (config.stack === "hono") {
     console.log(`   ${chalk.yellow("cd")} ${projectName}/client && ${chalk.green(cmd("dev"))}`);
     console.log(`   ${chalk.yellow("cd")} ${projectName}/server && ${chalk.green(cmd("dev"))}`);
@@ -148,6 +291,6 @@ export async function setupProject(projectName, config, installDeps) {
     console.log(`   ${chalk.yellow("cd")} ${projectName}/server && ${chalk.green(cmd("start"))}`);
   }
 
-  console.log(chalk.gray("-------------------------------------------"))
+  console.log(chalk.gray("-------------------------------------------"));
   console.log(chalk.gray("\n✨ Made with ❤️  by Celtrix ✨\n"));
 }

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1,0 +1,101 @@
+import chalk from "chalk";
+
+/**
+ * Returns true when an inquirer prompt was cancelled with Ctrl+C.
+ * Shared across the entire CLI to avoid duplicating this check.
+ *
+ * @param {unknown} error - Prompt error.
+ * @returns {boolean}
+ */
+export function isPromptCancellation(error) {
+  return (
+    error instanceof Error &&
+    (error.name === "ExitPromptError" ||
+      error.message.toLowerCase().includes("force closed"))
+  );
+}
+
+/**
+ * Builds the correct `create vite` command string for the given package
+ * manager, template, and output directory.
+ *
+ * This eliminates the repeated inline ternaries scattered across installer.js.
+ *
+ * @param {object} config - Project configuration.
+ * @param {string} config.packageManager - npm | yarn | pnpm | bun.
+ * @param {string} template - Vite template name (e.g. "react", "react-ts", "vue").
+ * @param {string} outputDir - Directory name for the scaffolded project (e.g. "client").
+ * @returns {string} Ready-to-exec shell command.
+ */
+export function buildViteCommand(config, template, outputDir) {
+  const pm = config.packageManager;
+  const vitePkg = pm === "npm" ? "vite@latest" : "vite";
+  const separator = pm === "npm" ? "--" : "";
+
+  return [
+    pm,
+    "create",
+    vitePkg,
+    outputDir,
+    separator,
+    `--t ${template}`,
+    "--no-rolldown",
+    "--no-interactive",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+/**
+ * Returns the correct install/add sub-command for a given package manager.
+ *
+ * @param {string} packageManager - npm | yarn | pnpm | bun.
+ * @returns {string} "install" for npm, "add" for everything else.
+ */
+export function getInstallCommand(packageManager) {
+  return packageManager === "npm" ? "install" : "add";
+}
+
+/**
+ * Celtrix "Powered by" badge CSS.
+ * Defined once and shared across all badge injectors.
+ */
+export const BADGE_CSS = `
+.powered-badge {
+  position: fixed;
+  bottom: 50%;
+  right: 1.5rem;
+  font-size: 1rem;
+  font-weight: 300;
+  background-color: black;
+  line-height: 1.5;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1),
+    0 4px 6px -2px rgba(0,0,0,0.05);
+  opacity: 0.8;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.powered-badge:hover {
+  opacity: 1;
+}
+
+.celtrix {
+  font-weight: 620;
+  font-size: 1.05rem;
+  color: #4ade80;
+  text-decoration: underline;
+}
+`;
+
+/**
+ * Badge HTML for React (JSX/TSX) projects.
+ */
+export const BADGE_JSX = `  <button className="powered-badge" onClick={() => window.open('https://github.com/celtrix-os/Celtrix', '_blank')}>Powered by <span className="celtrix">Celtrix</span></button>`;
+
+/**
+ * Badge HTML for Vue projects (uses @click instead of onClick).
+ */
+export const BADGE_VUE = `  <button class="powered-badge" @click="openCeltrix">Powered by <span class="celtrix">Celtrix</span></button>`;

--- a/utils/templateManager.js
+++ b/utils/templateManager.js
@@ -22,9 +22,15 @@ function addClientDockerfile(projectPath, _config) {
     return;
   }
 
+  // Select base image and install command based on runtime
+  const useBun = _config.runtime === "bun";
+  const baseImage = useBun ? "oven/bun:alpine" : "node:20-alpine";
+  const installCmd = useBun ? "bun install" : "npm install";
+  const buildCmd = useBun ? "bun run build" : "npm run build";
+
   // Create client Dockerfile for Vite-based projects
   const dockerfileContent = `# Build stage
-FROM node:20-alpine AS builder
+FROM ${baseImage} AS builder
 
 WORKDIR /app
 
@@ -32,13 +38,13 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm install
+RUN ${installCmd}
 
 # Copy source code
 COPY . .
 
 # Build the app
-RUN npm run build
+RUN ${buildCmd}
 
 # Production stage
 FROM nginx:alpine


### PR DESCRIPTION
### Description

This update transforms the Celtrix setup flow into a fully interactive experience by adding selection prompts for the entire stack (Runtime, Frontend, and Backend). 

**Major Changes:**
- **Runtime Prompt:** Added selection between `node` and `bun`.
- **Frontend Prompt:** Added support for 7 frameworks (React Router, Next.js, Nuxt, TanStack, Astro, Svelte, Solid).
- **Backend Prompt:** Added 5 options (Hono, Fastify, Express, Convex, None).
- **UX Refactor:** Integrated `ora` spinners for progress tracking and `boxen` for a clean project configuration summary at the end.
- **Robustness:** Fixed argument parsing logic to work across all package managers and added graceful `Ctrl+C` exit handling.

## Related Issue
Fixes #210
Fixes #211
Fixes #212

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Other (UI/UX Refactor)

## Checklist
- [x] My code follows the project’s style guidelines.
- [x] I have tested my changes locally.
- [x] I have updated documentation (if applicable).

## Additional Notes
The `config` object has been refactored to use object spreading, ensuring that all selections (runtime, frontend, backend) are correctly passed to the scaffolding engine. I also fixed a few typos in the help menu (e.g., "vannila" -> "vanilla").