### PR TITLE
fix: respect dependency installation prompt for Next.js

### DIFF
--- a/utils/installer.js
+++ b/utils/installer.js
@@ -402,7 +402,7 @@ export function mevnTailwindAuthSetup(projectPath, config, projectName, installD
   }
 }
 
-export function nextSetup(projectPath, config, projectName) {
+export function nextSetup(projectPath, config, projectName, installDeps) {
   try {
     function nextCommand() {
       switch (config.packageManager) {
@@ -414,16 +414,18 @@ export function nextSetup(projectPath, config, projectName) {
       }
     }
 
+    const installFlag = installDeps ? "" : " --skip-install";
+
     if (config.language === "typescript") {
       logger.info("⚡ Setting up Next.js with TypeScript...");
-      execSync(`${nextCommand()} . --typescript --eslint --tailwind --src-dir --app --no-turbo --import-alias="@/*" --yes`, {
+      execSync(`${nextCommand()} . --typescript --eslint --tailwind --src-dir --app --no-turbo --import-alias="@/*"${installFlag} --yes`, {
         cwd: projectPath,
         stdio: "inherit",
         shell: true,
       });
     } else if (config.language === "javascript") {
       logger.info("⚡ Setting up Next.js with JavaScript...");
-      execSync(`${nextCommand()} . --eslint --tailwind --src-dir --app --turbo --import-alias @/* --yes`, {
+      execSync(`${nextCommand()} . --eslint --tailwind --src-dir --app --turbo --import-alias @/*${installFlag} --yes`, {
         cwd: projectPath,
         stdio: "inherit",
         shell: true,

--- a/utils/project.js
+++ b/utils/project.js
@@ -228,7 +228,7 @@ export async function setupProject(projectName, config, installDeps) {
     }
 
     else if (config.stack === 'nextjs') {
-      nextSetup(projectPath, config, projectName);
+      nextSetup(projectPath, config, projectName, installDeps);
       copyTemplates(projectPath, config);
       logger.info("✅ Next.js project created successfully!");
     }


### PR DESCRIPTION
## Summary

Fixes issue #166 by ensuring Next.js project creation respects the dependency installation prompt.

## Changes

- Pass `installDeps` from `setupProject` to `nextSetup`
- Add conditional `--skip-install` flag when dependency installation is disabled
- Preserve existing behavior when dependency installation is enabled

## Testing

- Verified command generation for:
  - TypeScript + installDeps=true
  - TypeScript + installDeps=false
  - JavaScript + installDeps=true
  - JavaScript + installDeps=false
- Confirmed correct argument spacing and command construction
- Ran repository validation script (requires API keys not configured locally)

Closes #166