### PR TITLE
Improve CLI flow by prompting stack selection before project name

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ async function main() {
 
   // Handle help flag
   if (args.includes('--help') || args.includes('-h')) {
+
     showHelp();
     process.exit(0);
   }
@@ -104,11 +105,12 @@ async function main() {
 
     } else {
       // NORMAL MODE
+      const stackAnswers = await askStackQuestions();
+      
       if (!projectName) {
         projectName = await askProjectName();
       }
-
-      const stackAnswers = await askStackQuestions();
+     
 
       if (stackAnswers.stack === "custom") {
         // ── Custom Stack Flow ──


### PR DESCRIPTION
## Summary

This PR improves the CLI onboarding flow by changing the order of prompts during project creation.

### Changes Made

* Moved **stack selection** before the **project name** prompt in the normal project creation flow.
* Users now choose the technology stack first and then provide a project name.

### Previous Flow

```text
Banner
↓
Project Name
↓
Stack Selection
↓
Language
↓
Runtime
↓
Package Manager
```

### New Flow

```text
Banner
↓
Stack Selection
↓
Language
↓
Project Name
↓
Runtime
↓
Package Manager
```

### Why

Choosing the stack first helps users understand what they are building before naming the project. This creates a more intuitive onboarding experience and reduces friction for first-time users.

### Testing

* Verified that stack selection appears before the project name prompt.
* Tested the MERN + TypeScript flow successfully.
* Confirmed project scaffolding works as expected after the change.


Closes #244